### PR TITLE
Update language file translation review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,25 @@ Agents must follow these rules:
 - never change file structure
 - only update translated text values
 - preserve formatting
+- use the `Comment` column as review policy when CSV files include it
+- do not request translation of protected product names
+- preserve placeholders exactly, including `%1`, `%2`, and `%msg%`
+
+Protected Adiscon product names remain in English in every language:
+
+- EventReporter
+- MonitorWare Agent
+- RSyslog Windows Agent
+- WinSyslog
+
+For titles and labels such as "EventReporter Configuration Client" or "About
+EventReporter", translate only the surrounding UI wording if appropriate for the
+target language. The product name itself must remain unchanged.
+
+CSV review hints:
+
+- `PROTECTED_TERM`: preserve the product name spelling and capitalization.
+- `PLACEHOLDER_REQUIRED`: preserve placeholders exactly.
 
 ## Issue Handling Guidance
 

--- a/docs/language-file-format.md
+++ b/docs/language-file-format.md
@@ -10,6 +10,30 @@ The exact structure of a language file may differ by product and version. In gen
 
 Because formats may evolve over time, contributions should remain generic unless a specific product and version is clearly identified.
 
+Current exported CSV files use this structure:
+
+```text
+Unit,Unit Name,ID,Text,Comment
+```
+
+`Unit`, `Unit Name`, and `ID` identify the source UI element and must not be changed during translation review. `Text` is the user-visible value. `Comment` may contain policy hints for reviewers and translation tools.
+
+## Review policy hints
+
+The `Comment` column can contain these machine-readable hints:
+
+- `PROTECTED_TERM`: preserve the product name spelling and capitalization.
+- `PLACEHOLDER_REQUIRED`: preserve placeholders such as `%1`, `%2`, and `%msg%` exactly.
+
+Protected product names must remain in English in every language:
+
+- EventReporter
+- MonitorWare Agent
+- RSyslog Windows Agent
+- WinSyslog
+
+For titles and labels such as "EventReporter Configuration Client" or "About EventReporter", translators may localize "Configuration Client", "About", or the surrounding grammar, but the product name must stay unchanged.
+
 ## Customization use cases
 
 Typical use cases may include:


### PR DESCRIPTION
Document CSV review-policy hints for language files, including protected product/application titles and exact placeholder preservation. Clarify that translation review may update only translated text values while keeping keys, structure, product names, application titles, and placeholders unchanged.

Documentation-only change; reviewed against the captured diff for AGENTS.md and docs/language-file-format.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add translation review guidance for exported CSV language files, including the current structure: Unit, Unit Name, ID, Text, Comment. Document machine-readable hints in the `Comment` column (`PROTECTED_TERM`, `PLACEHOLDER_REQUIRED`), list protected Adiscon product names, and clarify that only `Text` may change; keys, structure, names, titles, and placeholders (e.g., `%1`, `%2`, `%msg%`) must remain unchanged.

<sup>Written for commit 7b2562a2706999e4f2e192342721168dac5da1e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

