### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -882,6 +882,9 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Wollen Sie 
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"Der Lizenzschlüssel ist für dieses Produkt ungültig. Er kann falsch eingegeben sein, nicht zum Lizenznamen passen oder beschädigt sein. Prüfen Sie die Einstellungen unter Allgemein.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,"Dieser Lizenzschlüssel ist für diese Produktversion ungültig (falsche Release- bzw. Hauptversion). Sie benötigen einen Schlüssel, der zu diesem Build passt. Aktualisieren Sie die Lizenz unter Allgemein.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Es ist kein Lizenzschlüssel hinterlegt (Lizenzname oder Hauptschlüssel fehlt). Geben Sie Ihre Lizenz unter Allgemein ein oder aktualisieren Sie sie.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Keine gültige Lizenzdatei konfiguriert,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Lizenzdatei gültig,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Kostenlose Version (Maximal %1 Sender),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,"Testphase ist abgelaufen, oder falsche Lizens!",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Testphase, Tage übrig ",
@@ -1657,7 +1660,30 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Key3,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Key4,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Key5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Lizenz verifizieren,
+ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Lizenz,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Legacy-Lizenzschlüssel,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,Für installierte Dienste mit Hauptversion vor 2026 verwenden Sie unten den Registrierungsnamen und die Lizenzschlüssel. Für Version 2026 und höher verwenden Sie die Registerkarte Lizenzdatei.,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Legacy-Lizenz,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Lizenz Informationen,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,Für installierte Dienste mit Hauptversion 2026 und höher verwenden Sie eine Lizenzdatei (.alic). Der Standardspeicherort ist %DEFAULTLICENSEV2PATH%. Für ältere Dienstversionen verwenden Sie die Registerkarte Legacy-Lizenz.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Lizenzdatei,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,"Standardpfad zur Laufzeit: %DEFAULTLICENSEV2PATH%. Feld leer lassen, um diesen Speicherort zu verwenden.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Lizenzdatei,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,.alic-Datei hier ablegen oder per Rechtsklick »Pfad einfügen« nach Explorer »Als Pfad kopieren« (wenn Drag-and-Drop blockiert ist).,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Nur .alic-Lizenzdateien können hier abgelegt werden.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Lizenzdatei,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Vorhandene license.alic am Standardspeicherort überschreiben?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Der eingefügte Pfad zur Lizenzdatei existiert nicht.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Die Zwischenablage enthält keinen gültigen Pfad zur Lizenzdatei.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PastePath,Pfad einfügen,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Path,Pfad zur Lizenzdatei,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInvalidConfirm,"Der Lizenzdateipfad konnte nicht überprüft werden:
+
+%1
+
+Diesen Pfad trotzdem speichern?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,Lizenzdatei,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Lizenzprüfung,
 ClientCore/xml.languagefiles/General.License,License General,szLicensee,Registrierungs-Name,
 ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Mehr Informationen unter auf unserer Homepage:,
 ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Lizenzschlüssel,

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -886,6 +886,9 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Do you want
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"The license key is not valid for this product. It may be mistyped, not match the license name, or be corrupted. Check General settings.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,This license key is not valid for this version of the product (wrong release / major version). You need a key that matches this build. Update your license in General settings.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,No license key is configured (license name or primary key is missing). Enter or update your license in General settings.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,No valid license file configured,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,License file valid,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Free Edition (Max %1 senders),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,Trial period expired or invalid license(wrong version?)!,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Trial period, days left ",
@@ -1662,7 +1665,30 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Key3,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Key4,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Key5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verify License,
+ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,License,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Legacy license keys,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"For installed services with major version before 2026, use the registration name and license keys below. For version 2026 and later, use the License File tab.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Legacy License,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,License Information,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"For installed services with major version 2026 and later, use a license file (.alic). The default location is %DEFAULTLICENSEV2PATH%. For older service versions, use the Legacy License tab.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,License File,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Default runtime path: %DEFAULTLICENSEV2PATH%. Leave this field empty to use that location.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,License File,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,"Drop a .alic file here, or right-click and choose Paste path after using Explorer Copy as path (useful when drag-and-drop is blocked).",
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Only .alic license files can be dropped here.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,License File,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Overwrite the existing license.alic at the default location?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,The pasted license file path does not exist.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,The clipboard does not contain a valid license file path.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PastePath,Paste path,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Path,License file path,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInvalidConfirm,"The license file path could not be verified:
+
+%1
+
+Save this path anyway?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,License File,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,License verification,
 ClientCore/xml.languagefiles/General.License,License General,szLicensee,Registration Name,
 ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,More information can be found at our Homepage,
 ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Registration Number,

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -886,6 +886,9 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,¿Desea rei
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La clave de licencia no es válida para este producto. Puede estar mal escrita, no coincidir con el nombre de licencia o estar corrupta. Revise la configuración general.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Esta clave de licencia no es válida para esta versión del producto (versión o release incorrecta). Necesita una clave que corresponda a esta compilación. Actualice la licencia en la configuración general.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,No hay clave de licencia configurada (falta el nombre de licencia o la clave principal). Introduzca o actualice su licencia en la configuración general.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,No hay un archivo de licencia válido configurado,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Archivo de licencia válido,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Edición gratuita (máx. %1 remitentes),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,¡Período de prueba expirado o licencia no válida (¿versión incorrecta?)!,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Período de prueba, días restantes ",
@@ -1656,7 +1659,30 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Clave3
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Clave4,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Clave5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verificar licencia,
+ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licencia,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Claves de licencia heredadas,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Para servicios instalados con versión principal anterior a 2026, use el nombre de registro y las claves de licencia siguientes. Para la versión 2026 y posteriores, use la pestaña Archivo de licencia.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licencia heredada,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Información de licencia,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Para servicios instalados con versión principal 2026 o posterior, use un archivo de licencia (.alic). La ubicación predeterminada es %DEFAULTLICENSEV2PATH%. Para versiones de servicio anteriores, use la pestaña Licencia heredada.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Archivo de licencia,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Ruta predeterminada en tiempo de ejecución: %DEFAULTLICENSEV2PATH%. Deje este campo vacío para usar esa ubicación.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Archivo de licencia,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Suelte un archivo .alic aquí o haga clic derecho y elija Pegar ruta tras Copiar como ruta en el Explorador (si el arrastrar y soltar está bloqueado).,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Solo se pueden soltar aquí archivos de licencia .alic.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Archivo de licencia,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,¿Sobrescribir el license.alic existente en la ubicación predeterminada?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,La ruta de archivo de licencia pegada no existe.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,El portapapeles no contiene una ruta de archivo de licencia válida.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PastePath,Pegar ruta,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Path,Ruta del archivo de licencia,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInvalidConfirm,"No se pudo verificar la ruta del archivo de licencia:
+
+%1
+
+¿Guardar esta ruta de todos modos?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,Archivo de licencia,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Verificación de licencia,
 ClientCore/xml.languagefiles/General.License,License General,szLicensee,Nombre de registro,
 ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Puede encontrar más información en nuestra página de inicio,
 ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Número de registro,

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -886,6 +886,9 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Kas soovite
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"Litsentsivõti ei kehti selle toote jaoks. See võib olla vale, mitte sobida litsentsi nimega või olla vigane. Kontrollige üldseadeid.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,See litsentsivõti ei kehti selle tooteversiooni jaoks (vale väljalaskenumber / peaversioon). Vajate sellele kompileeringule vastavat võtit. Uuendage litsents üldseadetes.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Litsentsivõtit pole seadistatud (puudub litsentsi nimi või põhivõti). Sisestage või uuendage litsents üldseadetes.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Väljaanne (Versioon ,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Kehtivat litsentsifaili pole seadistatud,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Litsentsifail kehtib,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Tasuta väljaanne (maksimaalselt %1 saatjat),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,Prooviperiood on aegunud või kehtetu litsents (vale versioon?)!,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Prooviperiood, päevad jäänud",
@@ -1662,7 +1665,30 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Võti 
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Võti 4,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Võti 5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Kinnitage litsents,
+ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Litsents,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Pärandlitsentsi võtmed,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Installitud teenuste puhul, mille peamine versioon on enne 2026, kasutage allpool registreerimisnime ja litsentsivõtmeid. Versiooni 2026 ja uuemate puhul kasutage vahekaarti Litsentsifail.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Pärandlitsents,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Litsentsi teave,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Installitud teenuste puhul, mille peamine versioon on 2026 või uuem, kasutage litsentsifaili (.alic). Vaikimisi asukoht on %DEFAULTLICENSEV2PATH%. Vanemate teenuseversioonide puhul kasutage vahekaarti Pärandlitsents.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Litsentsifail,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,"Vaikimisi käivitusteekond: %DEFAULTLICENSEV2PATH%. Jätke väli tühjaks, et kasutada seda asukohta.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Litsentsifail,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Lohistage .alic fail siia või tehke paremklõps ja valige Kleebi tee pärast Exploreris Kopeeri tee (kui lohistamine on blokeeritud).,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Siia saab lohistada ainult .alic litsentsifaile.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Litsentsifail,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Kas kirjutada vaikimisi asukohas olemasolev license.alic üle?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Kleebitud litsentsifaili teed ei eksisteeri.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Lõikelaual pole kehtivat litsentsifaili teed.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PastePath,Kleebi tee,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Path,Litsentsifaili tee,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInvalidConfirm,"Litsentsifaili teed ei saanud kontrollida:
+
+%1
+
+Kas salvestada see tee ikkagi?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,Litsentsifail,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Litsentsi kontroll,
 ClientCore/xml.languagefiles/General.License,License General,szLicensee,Registreerimisnimi,
 ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Lisateavet leiate meie kodulehelt,
 ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Registreerimisnumber,

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -886,6 +886,9 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Voulez-vous
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La clé de licence n'est pas valide pour ce produit. Elle peut être incorrecte, ne pas correspondre au nom de licence ou être corrompue. Vérifiez les paramètres généraux.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Cette clé de licence n'est pas valide pour cette version du produit (mauvaise version / release). Il faut une clé adaptée à cette build. Mettez à jour votre licence dans les paramètres généraux.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Aucune clé de licence n'est configurée (nom de licence ou clé principale manquant). Saisissez ou mettez à jour votre licence dans les paramètres généraux.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Aucun fichier de licence valide configuré,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Fichier de licence valide,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Édition gratuite (maximum de %1 expéditeurs),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,Période d'essai expirée ou licence invalide (mauvaise version ?) !,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Période d'essai, jours restants",
@@ -1662,7 +1665,30 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Clé3,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Clé4,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Clé5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Vérifier la licence,
+ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licence,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Clés de licence héritées,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Pour les services installés en version majeure antérieure à 2026, utilisez le nom d'enregistrement et les clés de licence ci-dessous. Pour la version 2026 et ultérieure, utilisez l'onglet Fichier de licence.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licence héritée,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Informations sur la licence,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Pour les services installés en version majeure 2026 ou ultérieure, utilisez un fichier de licence (.alic). L'emplacement par défaut est %DEFAULTLICENSEV2PATH%. Pour les versions de service plus anciennes, utilisez l'onglet Licence héritée.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Fichier de licence,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Chemin d'exécution par défaut : %DEFAULTLICENSEV2PATH%. Laissez ce champ vide pour utiliser cet emplacement.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Fichier de licence,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Déposez un fichier .alic ici ou cliquez droit et choisissez Coller le chemin après Copier comme chemin dans l'Explorateur (si le glisser-déposer est bloqué).,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Seuls les fichiers de licence .alic peuvent être déposés ici.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Fichier de licence,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Remplacer le license.alic existant à l'emplacement par défaut ?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Le chemin de fichier de licence collé n'existe pas.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Le presse-papiers ne contient pas de chemin de fichier de licence valide.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PastePath,Coller le chemin,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Path,Chemin du fichier de licence,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInvalidConfirm,"Le chemin du fichier de licence n'a pas pu être vérifié :
+
+%1
+
+Enregistrer ce chemin quand même ?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,Fichier de licence,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Vérification de licence,
 ClientCore/xml.languagefiles/General.License,License General,szLicensee,Nom d'enregistrement,
 ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Plus d'informations peuvent être trouvées sur notre page d'accueil,
 ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Numéro d'enregistrement,

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -886,6 +886,9 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Vuoi ricari
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La chiave di licenza non è valida per questo prodotto. Potrebbe essere errata, non corrispondere al nome licenza o essere corrotta. Controllare le impostazioni generali.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Questa chiave di licenza non è valida per questa versione del prodotto (versione/release errata). È necessaria una chiave adatta a questa build. Aggiornare la licenza nelle impostazioni generali.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Nessuna chiave di licenza configurata (manca il nome licenza o la chiave principale). Immettere o aggiornare la licenza nelle impostazioni generali.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Nessun file di licenza valido configurato,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,File di licenza valido,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Edizione gratuita (massimo %1 mittenti),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,Periodo di prova scaduto o licenza non valida (versione sbagliata?)!,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Periodo di prova, giorni rimasti",
@@ -1662,7 +1665,30 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Chiave
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Chiave4,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Chiave5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verifica licenza,
+ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licenza,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Chiavi di licenza legacy,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Per i servizi installati con versione principale precedente al 2026, usare il nome di registrazione e le chiavi di licenza sotto. Per la versione 2026 e successive, usare la scheda File di licenza.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licenza legacy,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Informazioni sulla licenza,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Per i servizi installati con versione principale 2026 o successiva, usare un file di licenza (.alic). La posizione predefinita è %DEFAULTLICENSEV2PATH%. Per versioni di servizio precedenti, usare la scheda Licenza legacy.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,File di licenza,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Percorso predefinito in runtime: %DEFAULTLICENSEV2PATH%. Lasciare vuoto per usare tale percorso.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,File di licenza,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Trascinare qui un file .alic o fare clic destro e scegliere Incolla percorso dopo Copia percorso in Esplora file (se il trascinamento è bloccato).,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Solo file di licenza .alic possono essere rilasciati qui.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,File di licenza,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Sovrascrivere il license.alic esistente nella posizione predefinita?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Il percorso del file di licenza incollato non esiste.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Gli appunti non contengono un percorso di file di licenza valido.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PastePath,Incolla percorso,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Path,Percorso file di licenza,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInvalidConfirm,"Impossibile verificare il percorso del file di licenza:
+
+%1
+
+Salvare comunque questo percorso?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,File di licenza,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Verifica licenza,
 ClientCore/xml.languagefiles/General.License,License General,szLicensee,Nome di registrazione,
 ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Maggiori informazioni possono essere trovate sulla nostra homepage,
 ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Numero di registrazione,

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -882,6 +882,9 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,リロー�
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,ライセンスキーはこの製品では無効です。誤入力、ライセンス名との不一致、またはデータ破損の可能性があります。一般設定を確認してください。,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,このライセンスキーはこの製品バージョンでは無効です（リリース／メジャーバージョンが一致しません）。このビルドに対応したキーが必要です。一般設定でライセンスを更新してください。,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,ライセンスキーが設定されていません（ライセンス名または主キーがありません）。一般設定でライセンスを入力または更新してください。,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,有効なライセンスファイルが設定されていません,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,ライセンスファイルは有効,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,フリーエディション (最大送信デバイス数：%1),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,試用期間は終了しました！,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,試用期間中/残り日数：,
@@ -1667,7 +1670,30 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Key3,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Key4,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Key5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,ライセンスを確認,
+ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,ライセンス,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,従来のライセンスキー,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,メジャーバージョン 2026 より前のインストール済みサービスでは、下の登録名とライセンスキーを使用してください。2026 以降のバージョンでは「ライセンスファイル」タブを使用してください。,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,従来のライセンス,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,ライセンス情報,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,メジャーバージョン 2026 以降のインストール済みサービスでは、ライセンスファイル (.alic) を使用します。既定の場所は %DEFAULTLICENSEV2PATH% です。それより古いサービスバージョンでは「従来のライセンス」タブを使用してください。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,ライセンスファイル,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,既定のランタイムパス: %DEFAULTLICENSEV2PATH%。このフィールドを空にするとその場所を使用します。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,ライセンスファイル,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,.alic ファイルをここにドロップするか、エクスプローラーで「パスのコピー」の後に右クリックして「パスを貼り付け」を選択してください（ドラッグアンドドロップがブロックされている場合）。,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,ここにドロップできるのは .alic ライセンスファイルのみです。,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,ライセンスファイル,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,既定の場所にある既存の license.alic を上書きしますか？,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,貼り付けたライセンスファイルのパスが存在しません。,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,クリップボードに有効なライセンスファイルのパスが含まれていません。,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PastePath,パスを貼り付け,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Path,ライセンスファイルのパス,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInvalidConfirm,"ライセンスファイルのパスを確認できませんでした:
+
+%1
+
+このパスを保存しますか?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,ライセンスファイル,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,ライセンス検証,
 ClientCore/xml.languagefiles/General.License,License General,szLicensee,ユーザー登録名,
 ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,詳細情報は以下...,
 ClientCore/xml.languagefiles/General.License,License General,szRegNumber,ユーザー登録番号,

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -885,6 +885,9 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Quer recarr
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"A chave de licença não é válida para este produto. Ela pode estar incorreta, não corresponder ao nome da licença ou estar corrompida. Verifique as configurações gerais.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Esta chave de licença não é válida para esta versão do produto (versão/release incorreta). É necessária uma chave compatível com esta compilação. Atualize a licença em Configurações gerais.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Nenhuma chave de licença configurada (falta o nome da licença ou a chave principal). Informe ou atualize a licença em Configurações gerais.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Nenhum arquivo de licença válido configurado,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Arquivo de licença válido,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Edição gratuita (máximo de %1 remetentes),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,Período de teste expirou ou licença inválida (versão errada?)!,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Período de teste, dias restantes",
@@ -1661,7 +1664,30 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Chave3
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Chave4,
 ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Chave5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verifique a licença,
+ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licença,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Chaves de licença legadas,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Para serviços instalados com versão principal anterior a 2026, use o nome de registro e as chaves de licença abaixo. Para a versão 2026 e posterior, use a guia Arquivo de licença.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licença legada,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Informações sobre licença,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Para serviços instalados com versão principal 2026 ou posterior, use um arquivo de licença (.alic). O local padrão é %DEFAULTLICENSEV2PATH%. Para versões de serviço mais antigas, use a guia Licença legada.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Arquivo de licença,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Caminho padrão em runtime: %DEFAULTLICENSEV2PATH%. Deixe vazio para usar esse local.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Arquivo de licença,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Solte um arquivo .alic aqui ou clique com o botão direito e escolha Colar caminho após Copiar como caminho no Explorer (quando arrastar e soltar estiver bloqueado).,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Somente arquivos de licença .alic podem ser soltos aqui.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Arquivo de licença,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Substituir o license.alic existente no local padrão?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,O caminho do arquivo de licença colado não existe.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,A área de transferência não contém um caminho de arquivo de licença válido.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PastePath,Colar caminho,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Path,Caminho do arquivo de licença,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInvalidConfirm,"Não foi possível verificar o caminho do arquivo de licença:
+
+%1
+
+Salvar este caminho mesmo assim?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,Arquivo de licença,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Verificação de licença,
 ClientCore/xml.languagefiles/General.License,License General,szLicensee,Nome de registro,
 ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Mais informações podem ser encontradas em nossa página inicial,
 ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Número de registro,


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: b368989b0003b70e08a210e127d265cddc4908f3
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new license file (.alic) licensing texts and legacy-license guidance to the Adiscon Client across 8 locales. This supports the 2026+ licensing flow with clearer status, path, and validation messages.

- **New Features**
  - Added strings for the new “License File” workflow (.alic) for 2026+ services: default path (%DEFAULTLICENSEV2PATH%), drag-and-drop/paste-path hints, verification, overwrite, and error prompts; plus status labels for missing/valid file and an Edition/Version suffix.
  - Updated locales: en-US, de-DE, es-ES, et-EE, fr-FR, it-IT, ja-JP, pt-BR; CSV keys/structure unchanged and placeholders like %1 and %DEFAULTLICENSEV2PATH% are preserved.

<sup>Written for commit e272f947cf4353bb39ece3140af76b7d53a5c513. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

