### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -857,10 +857,16 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Fehler beim spei
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Datenvariablen konnten nicht in folgendes Verzeichnis gespeichert werden: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,The following Service has no RuleSet assigned: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,Der folgende Dienste wird mit ihrer aktuellen Lizenz nicht funktionieren: ,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Fehler beim Service Start,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,Der Service konnte nach 20 Sek. nicht gestartet werden.,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,Fehler beim Service Stop,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,Der Service konnte nach 20 Sek. nicht gestoppt werden.,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Service-Start dauert länger als erwartet,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"Der Configuration Client hat nach 30 Sekunden aufgehört zu warten. Der Hintergrunddienst wird möglicherweise noch gestartet.
+
+Bitte prüfen Sie die Windows-Diensteverwaltung (services.msc) auf den aktuellen Status.",
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,Service-Stopp dauert länger als erwartet,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,"Der Configuration Client hat nach 30 Sekunden aufgehört zu warten. Der Hintergrunddienst wird möglicherweise noch heruntergefahren.
+
+Bitte prüfen Sie die Windows-Diensteverwaltung (services.msc) auf den aktuellen Status. Wenn der Status „Wird beendet“ lautet, warten Sie, bis er „Beendet“ ist.
+
+Bleibt der Dienst im Status „Wird beendet“ lange im Leerlauf, prüfen Sie in Ihrer Produktdokumentation Allgemein > Service gegen Herunterfahren sichern und wenden Sie sich an den Support.",
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigFailed,Export der Konfiguration in Datei fehlgeschlagen ,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigSuccess,Export der Konfiguration in Datei erfolgreich ,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigTitle,Konfiguration Export,
@@ -906,8 +912,13 @@ ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Startet
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Startet den Hintergrunddienst,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Stoppt den Hintergrunddienst,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Serviceverwaltung,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Dienst: Angehalten (Neuladen),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Dienst: Wird angehalten,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Dienst: Wird fortgesetzt,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Dienst: Läuft,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Dienst: Wird gestartet,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Dienst: Gestoppt,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Dienst: Wird beendet,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Dienst: Unbekannt,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Dienste,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,Es wurden %1 Dienste aus der Konfigurationsdatei '%2' importiert.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -861,10 +861,16 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Failed to save d
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Saving data variables failed for the following directory: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,The following Service has no RuleSet assigned: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,The following Service will not work with your current license: ,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Error Starting Service,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,The Service could not be started in 20 seconds.,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,Error Stopping Service,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,The Service could not be stopped in 20 seconds.,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Service start is taking longer than expected,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"The Configuration Client stopped waiting after 30 seconds. The background service may still be starting.
+
+Please check the Windows Services console (services.msc) for the current status.",
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,Service stop is taking longer than expected,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,"The Configuration Client stopped waiting after 30 seconds. The background service may still be shutting down.
+
+Please check the Windows Services console (services.msc) for the current status. If the status is Stopping, wait until it becomes Stopped.
+
+If the service stays in Stopping for a long time while the system is idle, review General > Protect against shutdown in your product documentation and contact support.",
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigFailed,Failed to export configuration into file ,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigSuccess,Successfully exported configuration into file ,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigTitle,Configuration Export,
@@ -910,8 +916,13 @@ ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Restart
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Starts the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Stops the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Service Management,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Service: Paused (Reloading),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Service: Pausing,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Service: Resuming,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Service: Running,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Service: Starting,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Service: Stopped,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Service: Stopping,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Service: Unknown,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Services,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,Imported %1 Services from configuration file '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -861,10 +861,16 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Error al guardar
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Error al guardar las variables de datos para el siguiente directorio: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,El siguiente servicio no tiene ningún conjunto de reglas asignado: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,El siguiente servicio no funcionará con su licencia actual: ,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Error al iniciar el servicio,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,El servicio no pudo iniciarse en 20 segundos.,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,Error al detener el servicio,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,El servicio no pudo detenerse en 20 segundos.,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,El inicio del servicio está tardando más de lo esperado,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"El Configuration Client dejó de esperar tras 30 segundos. El servicio en segundo plano puede seguir iniciándose.
+
+Compruebe el estado actual en la consola de servicios de Windows (services.msc).",
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,La detención del servicio está tardando más de lo esperado,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,"El Configuration Client dejó de esperar tras 30 segundos. El servicio en segundo plano puede seguir deteniéndose.
+
+Compruebe el estado actual en la consola de servicios de Windows (services.msc). Si el estado es «Deteniendo», espere hasta que pase a «Detenido».
+
+Si el servicio permanece en «Deteniendo» mucho tiempo con el sistema inactivo, revise en la documentación de su producto General > Proteger servicio contra cierre y contacte con el soporte.",
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigFailed,Error al exportar la configuración al archivo ,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigSuccess,Configuración exportada correctamente al archivo ,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigTitle,Exportar configuración,
@@ -910,8 +916,13 @@ ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Reinici
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Inicia el servicio en segundo plano,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Detiene el servicio en segundo plano,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Administración de servicios,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Servicio: En pausa (Recargando),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Servicio: Pausando,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Servicio: Reanudando,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Servicio: En ejecución,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Servicio: Iniciando,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Servicio: Detenido,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Servicio: Deteniendo,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Servicio: Desconocido,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Servicios,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,Se importó %1 Services del archivo de configuración '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -861,10 +861,16 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Andmemuutujate s
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Andmemuutujate salvestamine ebaõnnestus järgmises kataloogis:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,Järgmisele teenusele ei ole reeglistikku määratud:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,Järgmine teenus ei tööta teie praeguse litsentsiga:,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Viga teenuse käivitamisel,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,Teenust ei õnnestunud 20 sekundi jooksul käivitada.,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,Viga teenuse peatamisel,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,Teenust ei õnnestunud 20 sekundi jooksul peatada.,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Teenuse käivitamine võtab oodatust kauem aega,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"Configuration Client lõpetas ootamise 30 sekundi järel. Taustateenus võib endiselt käivituda.
+
+Kontrollige praegust olekut Windowsi teenuste konsoolis (services.msc).",
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,Teenuse peatamine võtab oodatust kauem aega,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,"Configuration Client lõpetas ootamise 30 sekundi järel. Taustateenus võib endiselt sulguda.
+
+Kontrollige praegust olekut Windowsi teenuste konsoolis (services.msc). Kui olek on „Peatamine“, oodake, kuni see muutub „Peatatud“.
+
+Kui teenus jääb pikaks ajaks olekusse „Peatamine“ süsteemi jõudeolekus, vaadake toote dokumentatsioonist Üldine > Kaitse teenust väljalülitamise eest ja võtke ühendust toega.",
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigFailed,Konfiguratsiooni faili eksportimine ebaõnnestus,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigSuccess,Konfiguratsiooni eksportimine õnnestus faili,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigTitle,Konfiguratsiooni eksport,
@@ -910,8 +916,13 @@ ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Restart
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Starts the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Stops the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Teenuse haldus,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Teenus: peatatud (uuesti laadimine),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Teenus: peatamise ootel,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Teenus: jätkamine,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Teenus: töötab,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Teenus: käivitamine,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Teenus: peatatud,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Teenus: peatamine,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Teenus: teadmata,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Teenused,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,Imporditud %1 teenust konfiguratsioonifailist '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -861,10 +861,16 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Échec de l'enre
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Échec de l'enregistrement des variables de données pour le répertoire suivant :,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,Le service suivant n'a aucun RuleSet attribué :,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,Le service suivant ne fonctionnera pas avec votre licence actuelle :,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Erreur de démarrage du service,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,Le service n'a pas pu être démarré en 20 secondes.,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,Erreur lors de l'arrêt du service,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,Le Service n'a pas pu être arrêté en 20 secondes.,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Le démarrage du service prend plus de temps que prévu,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"Le Configuration Client a cessé d'attendre après 30 secondes. Le service en arrière-plan peut encore être en cours de démarrage.
+
+Veuillez vérifier l'état actuel dans la console des services Windows (services.msc).",
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,L'arrêt du service prend plus de temps que prévu,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,"Le Configuration Client a cessé d'attendre après 30 secondes. Le service en arrière-plan peut encore être en cours d'arrêt.
+
+Veuillez vérifier l'état actuel dans la console des services Windows (services.msc). Si l'état est « Arrêt en cours », attendez qu'il passe à « Arrêté ».
+
+Si le service reste longtemps à l'état « Arrêt en cours » alors que le système est inactif, consultez la documentation de votre produit sous Général > Protéger le service contre l'arrêt et contactez le support.",
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigFailed,Échec de l'exportation de la configuration dans un fichier,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigSuccess,Configuration exportée avec succès dans un fichier,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigTitle,Exportation de configurations,
@@ -910,8 +916,13 @@ ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Redéma
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Démarre le service en arrière-plan,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Arrête le service en arrière-plan,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Gestion des services,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Service : En pause (Rechargement),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Service : Mise en pause,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Service : Reprise en cours,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Service : En cours d'exécution,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Service : Démarrage en cours,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Service : Arrêté,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Service : Arrêt en cours,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Service : Inconnu,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Services,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,Services %1 importés à partir du fichier de configuration '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -861,10 +861,16 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Impossibile salv
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Il salvataggio delle variabili di dati non è riuscito per la seguente directory:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,Al seguente servizio non è assegnato alcun set di regole:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,Il seguente servizio non funzionerà con la licenza attuale:,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Errore durante l'avvio del servizio,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,Impossibile avviare il servizio entro 20 secondi.,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,Errore durante l'arresto del servizio,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,Impossibile arrestare il servizio entro 20 secondi.,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,L'avvio del servizio sta richiedendo più tempo del previsto,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"Il Configuration Client ha interrotto l'attesa dopo 30 secondi. Il servizio in background potrebbe essere ancora in avvio.
+
+Verificare lo stato attuale nella console Servizi di Windows (services.msc).",
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,L'arresto del servizio sta richiedendo più tempo del previsto,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,"Il Configuration Client ha interrotto l'attesa dopo 30 secondi. Il servizio in background potrebbe essere ancora in arresto.
+
+Verificare lo stato attuale nella console Servizi di Windows (services.msc). Se lo stato è «In arresto», attendere fino a «Arrestato».
+
+Se il servizio resta a lungo nello stato «In arresto» a sistema inattivo, consultare la documentazione del prodotto in Generale > Proteggi il servizio dallo spegnimento e contattare il supporto.",
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigFailed,Impossibile esportare la configurazione nel file,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigSuccess,Configurazione esportata correttamente nel file,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigTitle,Esportazione della configurazione,
@@ -910,8 +916,13 @@ ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Restart
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Starts the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Stops the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Gestione dei servizi,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Servizio: in pausa (Ricaricamento),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Servizio: pausa in corso,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Servizio: ripresa in corso,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Servizio: in esecuzione,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Servizio: in avvio,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Servizio: arrestato,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Servizio: in arresto,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Servizio: sconosciuto,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Servizi,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,%1 servizi importati dal file di configurazione '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -857,10 +857,16 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,データ変数�
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,以下のディレクトリでデータ変数の保存に失敗しました: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,以下のサービスはルールセットが設定されていません: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,このサービスはお持ちのライセンスでは使用できません:,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,サービスの開始エラー,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,20秒以内にサービスを開始できませんでした,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,サービスの停止エラー,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,20秒以内にサービスを停止できませんでした,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,サービスの開始に予想より時間がかかっています,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"30秒経過後、Configuration Clientは待機を終了しました。バックグラウンド サービスはまだ開始中の可能性があります。
+
+Windows のサービス コンソール (services.msc) で現在の状態を確認してください。",
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,サービスの停止に予想より時間がかかっています,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,"30秒経過後、Configuration Clientは待機を終了しました。バックグラウンド サービスはまだシャットダウン中の可能性があります。
+
+Windows のサービス コンソール (services.msc) で現在の状態を確認してください。状態が「停止中」の場合は、「停止」になるまでお待ちください。
+
+システムがアイドル状態なのにサービスが長時間「停止中」のままの場合は、製品ドキュメントの全般 > シャットダウン時にサービスを保護する を確認し、サポートにお問い合わせください。",
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigFailed,ファイルへの設定のエクスポートに失敗しました,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigSuccess,ファイルへの設定のエクスポートに成功しました,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigTitle,設定のエクスポート,
@@ -906,8 +912,13 @@ ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,バッ�
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,バックグラウンド サービスを開始します,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,バックグラウンド サービスを停止します,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,サービス管理,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,サービス: 一時停止 (再読み込み中),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,サービス: 一時停止中,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,サービス: 再開中,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,サービス: 実行中,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,サービス: 開始中,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,サービス: 停止,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,サービス: 停止中,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,サービス: 不明,
 ClientCore/frmMainTemplate,Main Template Form,szServices,サービス,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,サービス %1 を設定ファイル '%2' からインポートしました,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -860,10 +860,16 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Falha ao salvar 
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Falha ao salvar variáveis ​​de dados para o seguinte diretório:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,O serviço a seguir não tem conjunto de regras atribuído:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,O serviço a seguir não funcionará com sua licença atual:,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Erro ao iniciar o serviço,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,O serviço não pôde ser iniciado em 20 segundos.,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,Erro ao parar o serviço,
-ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,O serviço não pôde ser interrompido em 20 segundos.,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,A inicialização do serviço está demorando mais do que o esperado,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"O Configuration Client parou de aguardar após 30 segundos. O serviço em segundo plano ainda pode estar iniciando.
+
+Verifique o status atual no console de Serviços do Windows (services.msc).",
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingService,A parada do serviço está demorando mais do que o esperado,
+ClientCore/frmMainTemplate,Main Template Form,szErrorStoppingServiceMsg,"O Configuration Client parou de aguardar após 30 segundos. O serviço em segundo plano ainda pode estar sendo encerrado.
+
+Verifique o status atual no console de Serviços do Windows (services.msc). Se o status for «Parando», aguarde até que fique «Parado».
+
+Se o serviço permanecer em «Parando» por muito tempo com o sistema ocioso, consulte a documentação do produto em Geral > Proteger o serviço contra desligamento e entre em contato com o suporte.",
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigFailed,Falha ao exportar a configuração para o arquivo,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigSuccess,Configuração exportada com sucesso para arquivo,
 ClientCore/frmMainTemplate,Main Template Form,szExportConfigTitle,Exportação de configuração,
@@ -909,8 +915,13 @@ ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Reinici
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Inicia o serviço em segundo plano,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Para o serviço em segundo plano,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Gerenciamento de serviços,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Serviço: em pausa (Recarregando),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Serviço: pausando,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Serviço: retomando,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Serviço: em execução,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Serviço: iniciando,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Serviço: parado,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Serviço: parando,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Serviço: desconhecido,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Serviços,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,%1 serviços importados do arquivo de configuração '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: 744d10c1335e1383fb8596dd6ca39d063afdbdb8
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `clientcore` language CSVs to add new service status strings and clarify start/stop timeout messages across eight locales. This improves guidance when services take longer to start or stop.

- **New Features**
  - Added translations for new service statuses: Paused (Reloading), Pausing, Resuming, Starting, Stopping in de-DE, en-US, es-ES, et-EE, fr-FR, it-IT, ja-JP, pt-BR.
  - Replaced 20s error text with 30s “taking longer than expected” messages, including instructions to check services.msc and a shutdown-protection note where applicable; CSV keys/structure and placeholders preserved, protected product names unchanged.

<sup>Written for commit 82479a97d9879920c5af8f04ac1182927694c458. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

