### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -762,6 +762,7 @@ ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceDisplayName.Text,NT Se
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceMonitor.Text,NT Service Monitor,
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceName.Text,NT Service Name,
 ClientCore/frmMainTemplate,Main Template Form,mnuNetworkDiscovery.Text,Netzwerk durchsuchen,
+ClientCore/frmMainTemplate,Main Template Form,mnuOpenWindowsServices.Text,Windows-Dienste öffnen,
 ClientCore/frmMainTemplate,Main Template Form,mnuOptions.Text,Optionen,
 ClientCore/frmMainTemplate,Main Template Form,mnuOtherServices.Text,Andere Dienste,
 ClientCore/frmMainTemplate,Main Template Form,mnuPOP3Probe.Text,POP3 Probe,
@@ -855,8 +856,19 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfiguration,Fehler 
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfigurationText,Die Konfiguration konnte nicht gespeichert werden:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Fehler beim speichern von datenvariablen,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Datenvariablen konnten nicht in folgendes Verzeichnis gespeichert werden: ,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlocked,Dienst akzeptiert keine Steuerbefehle,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedMsg,"Windows-Fehler 1061: Der Dienst akzeptiert derzeit keine Befehle zum Stoppen, Starten oder Neustarten. Der Dienst ist möglicherweise beschäftigt oder in einem inkonsistenten Zustand.
+
+Möchten Sie den Hintergrunddienstprozess zwangsweise beenden? Nicht gespeicherte Daten können verloren gehen.",
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedNoProcessMsg,"Windows-Fehler 1061: Der Dienst akzeptiert derzeit keine Steuerbefehle.
+
+Es wurde kein Hintergrunddienstprozess gefunden. Bitte warten und die Windows-Diensteverwaltung (services.msc) prüfen.",
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,The following Service has no RuleSet assigned: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,Der folgende Dienste wird mit ihrer aktuellen Lizenz nicht funktionieren: ,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePaused,Dienst lädt die Konfiguration neu,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePausedMsg,"Der Hintergrunddienst ist angehalten, während die Konfiguration neu geladen wird. Stoppen und Neustart sind derzeit deaktiviert, da sie den Dienst instabil machen können.
+
+Bitte warten, bis der Status wieder Running anzeigt.",
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Service-Start dauert länger als erwartet,
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"Der Configuration Client hat nach 30 Sekunden aufgehört zu warten. Der Hintergrunddienst wird möglicherweise noch gestartet.
 
@@ -881,6 +893,16 @@ ClientCore/frmMainTemplate,Main Template Form,szImportingConfiguration,Importier
 ClientCore/frmMainTemplate,Main Template Form,szInitClient,Initialisiere Client,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDef,Init Konfigurationsdefinitionen,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDisplay,Init Konfigurationsdarstellung,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmMsg,Der Hintergrunddienstprozess wird zwangsweise beendet. Nicht gespeicherte Daten können verloren gehen. Fortfahren?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmTitle,Dienstprozess beenden?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailed,Dienstprozess konnte nicht beendet werden,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailedMsg,"Der Configuration Client konnte den Hintergrunddienstprozess nicht beenden. Der Prozess ist möglicherweise geschützt oder der Client benötigt Administratorrechte.
+
+Versuchen Sie es erneut mit erhöhten Rechten oder beenden Sie den Prozess über den Windows Task-Manager oder services.msc.",
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailed,Nicht alle Dienstprozesse konnten beendet werden,
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailedMsg,"Mindestens ein passender Hintergrunddienstprozess wurde beendet, aber ein weiterer passender Prozess läuft noch.
+
+Versuchen Sie es erneut mit erhöhten Rechten oder beenden Sie den verbleibenden Prozess über den Windows Task-Manager oder services.msc.",
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Spracheinstellungen wurden verändert,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Sie haben die Spracheinstellungen verändert.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,"Der Konfigurationsclient muss neu geladen werden, damit die Änderung durchgeführt werden kann.",
@@ -908,17 +930,32 @@ ClientCore/frmMainTemplate,Main Template Form,szResetDefaultTitle,Auf Default zu
 ClientCore/frmMainTemplate,Main Template Form,szRuleSets,Regelsätze,
 ClientCore/frmMainTemplate,Main Template Form,szRuleSetsAdded,Es wurden %1 Regelsätze aus der Konfigurationsdatei '%2' importiert. ,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szSavingConfiguration,Speichere Konfiguration ...,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledControlBlocked,"Windows kann derzeit keine Dienststeuerbefehle senden — Stop erneut verwenden, um den Prozess zu beenden, oder services.msc prüfen",
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledInProgress,Dienststeuerung vorübergehend nicht verfügbar,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNoAccess,Dienst kann nicht gesteuert werden — Configuration Client ggf. als Administrator starten,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNotInstalled,Der Windows-Dienst ist nicht installiert,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledOrphan,Dienstprozess läuft ohne Windows-Dienststeuerung — Dienst beenden im Menü Extras verwenden,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPaused,Dienst ist angehalten (Konfiguration wird neu geladen) — Stoppen und Neustart sind bis zum Ende des Neuladens deaktiviert,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPausing,Dienst wird angehalten — bitte warten,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledResuming,Dienst wird fortgesetzt — bitte warten,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStarting,Dienst wird gestartet — bitte warten,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStopping,Dienst wird gestoppt — bitte warten,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Startet den Hintergrunddienst neu,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Startet den Hintergrunddienst,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Stoppt den Hintergrunddienst,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Serviceverwaltung,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusControlBlocked,Dienst: Steuerung nicht verfügbar,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Dienst: Angehalten (Neuladen),
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Dienst: Wird angehalten,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusProcessWithoutService,Dienst: Prozess läuft ohne Dienst,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Dienst: Wird fortgesetzt,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Dienst: Läuft,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Dienst: Wird gestartet,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Dienst: Gestoppt,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Dienst: Wird beendet,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableAccessDenied,Dienst: Abfrage nicht möglich (Zugriff verweigert),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableNotInstalled,Dienst: Nicht installiert,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableWin32,Dienst: Nicht verfügbar,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Dienst: Unbekannt,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Dienste,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,Es wurden %1 Dienste aus der Konfigurationsdatei '%2' importiert.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -766,6 +766,7 @@ ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceDisplayName.Text,NT Se
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceMonitor.Text,NT Service Monitor,
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceName.Text,NT Service Name,
 ClientCore/frmMainTemplate,Main Template Form,mnuNetworkDiscovery.Text,Network Discovery,
+ClientCore/frmMainTemplate,Main Template Form,mnuOpenWindowsServices.Text,Open Windows Services,
 ClientCore/frmMainTemplate,Main Template Form,mnuOptions.Text,Options,
 ClientCore/frmMainTemplate,Main Template Form,mnuOtherServices.Text,Other Services,
 ClientCore/frmMainTemplate,Main Template Form,mnuPOP3Probe.Text,POP3 Probe,
@@ -859,8 +860,19 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfiguration,Error S
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfigurationText,The Configuration could not be saved: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Failed to save data variables,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Saving data variables failed for the following directory: ,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlocked,Service cannot accept control commands,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedMsg,"Windows error 1061: The service cannot accept stop, start, or restart commands right now. The service may be busy or in an inconsistent state.
+
+Do you want to forcibly terminate the background service process? Unsaved data may be lost.",
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedNoProcessMsg,"Windows error 1061: The service cannot accept stop, start, or restart commands right now.
+
+No background service process was found. Please wait and check the Windows Services console (services.msc).",
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,The following Service has no RuleSet assigned: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,The following Service will not work with your current license: ,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePaused,Service is reloading configuration,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePausedMsg,"The background service is paused while it reloads configuration. Stop and Restart are disabled at this time because they can leave the service in an unstable state.
+
+Please wait until the status returns to Running.",
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Service start is taking longer than expected,
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"The Configuration Client stopped waiting after 30 seconds. The background service may still be starting.
 
@@ -885,6 +897,16 @@ ClientCore/frmMainTemplate,Main Template Form,szImportingConfiguration,Importing
 ClientCore/frmMainTemplate,Main Template Form,szInitClient,Initiating Client,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDef,Init configuration definitions,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDisplay,Init configuration display,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmMsg,This will forcibly terminate the background service process. Unsaved data may be lost. Continue?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmTitle,Kill service process?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailed,Could not kill service process,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailedMsg,"The Configuration Client could not terminate the background service process. The process may be protected or the client may need to run with administrator rights.
+
+Please try again from an elevated session, or end the process using Windows Task Manager or services.msc.",
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailed,Could not kill all service processes,
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailedMsg,"At least one matching background service process was terminated, but another matching process is still running.
+
+Please try again from an elevated session, or end the remaining process using Windows Task Manager or services.msc.",
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Language Settings changed,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,You have changed the language settings.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,A reload of the Client application is needed in order to complete the changes.,
@@ -912,17 +934,32 @@ ClientCore/frmMainTemplate,Main Template Form,szResetDefaultTitle,Reset to defau
 ClientCore/frmMainTemplate,Main Template Form,szRuleSets,RuleSets,
 ClientCore/frmMainTemplate,Main Template Form,szRuleSetsAdded,Imported %1 RuleSets from configuration file '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szSavingConfiguration,Saving configuration ...,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledControlBlocked,"Windows cannot send service control commands right now — use Stop again to kill the process, or check services.msc",
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledInProgress,Service control is temporarily unavailable,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNoAccess,Cannot control the service — try running the Configuration Client as administrator,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNotInstalled,The Windows service is not installed,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledOrphan,Service process is running without Windows service control — use Kill service from the Tools menu,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPaused,Service is paused (reloading configuration) — Stop and Restart are disabled until reload completes,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPausing,Service is pausing — please wait,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledResuming,Service is resuming — please wait,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStarting,Service is starting — please wait,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStopping,Service is stopping — please wait,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Restarts the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Starts the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Stops the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Service Management,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusControlBlocked,Service: Control unavailable,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Service: Paused (Reloading),
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Service: Pausing,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusProcessWithoutService,Service: Process running without service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Service: Resuming,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Service: Running,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Service: Starting,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Service: Stopped,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Service: Stopping,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableAccessDenied,Service: Cannot query service (access denied),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableNotInstalled,Service: Not installed,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableWin32,Service: Unavailable,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Service: Unknown,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Services,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,Imported %1 Services from configuration file '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -766,6 +766,7 @@ ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceDisplayName.Text,NT Se
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceMonitor.Text,Monitor de servicio NT,
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceName.Text,NT Service Nombre,
 ClientCore/frmMainTemplate,Main Template Form,mnuNetworkDiscovery.Text,Detección de red,
+ClientCore/frmMainTemplate,Main Template Form,mnuOpenWindowsServices.Text,Abrir servicios de Windows,
 ClientCore/frmMainTemplate,Main Template Form,mnuOptions.Text,Opciones,
 ClientCore/frmMainTemplate,Main Template Form,mnuOtherServices.Text,Otros servicios,
 ClientCore/frmMainTemplate,Main Template Form,mnuPOP3Probe.Text,Sonda POP3,
@@ -859,8 +860,19 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfiguration,Error a
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfigurationText,No se pudo guardar la configuración: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Error al guardar las variables de datos,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Error al guardar las variables de datos para el siguiente directorio: ,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlocked,El servicio no acepta comandos de control,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedMsg,"Error de Windows 1061: El servicio no puede aceptar comandos de detener, iniciar o reiniciar en este momento. Puede estar ocupado o en un estado inconsistente.
+
+¿Desea finalizar forzosamente el proceso del servicio en segundo plano? Se pueden perder datos no guardados.",
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedNoProcessMsg,"Error de Windows 1061: El servicio no puede aceptar comandos de control en este momento.
+
+No se encontró ningún proceso del servicio en segundo plano. Espere y compruebe la consola de servicios de Windows (services.msc).",
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,El siguiente servicio no tiene ningún conjunto de reglas asignado: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,El siguiente servicio no funcionará con su licencia actual: ,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePaused,El servicio está recargando la configuración,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePausedMsg,"El servicio en segundo plano está en pausa mientras recarga la configuración. Detener y Reiniciar están deshabilitados porque pueden dejar el servicio inestable.
+
+Espere hasta que el estado vuelva a En ejecución.",
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,El inicio del servicio está tardando más de lo esperado,
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"El Configuration Client dejó de esperar tras 30 segundos. El servicio en segundo plano puede seguir iniciándose.
 
@@ -885,6 +897,16 @@ ClientCore/frmMainTemplate,Main Template Form,szImportingConfiguration,Importand
 ClientCore/frmMainTemplate,Main Template Form,szInitClient,Iniciando cliente,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDef,Inicializando definiciones de configuración,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDisplay,Inicializando visualización de configuración,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmMsg,Se terminará forzosamente el proceso del servicio en segundo plano. Se pueden perder datos no guardados. ¿Continuar?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmTitle,¿Finalizar el proceso del servicio?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailed,No se pudo finalizar el proceso del servicio,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailedMsg,"El Configuration Client no pudo terminar el proceso del servicio en segundo plano. El proceso puede estar protegido o el cliente puede necesitar ejecutarse como administrador.
+
+Inténtelo de nuevo con privilegios elevados o finalice el proceso con el Administrador de tareas de Windows o services.msc.",
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailed,No se pudieron finalizar todos los procesos del servicio,
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailedMsg,"Se terminó al menos un proceso coincidente del servicio en segundo plano, pero otro proceso coincidente sigue en ejecución.
+
+Inténtelo de nuevo con privilegios elevados o finalice el proceso restante con el Administrador de tareas de Windows o services.msc.",
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Configuración de idioma cambiada,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Ha cambiado la configuración de idioma.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Es necesario reiniciar la aplicación cliente para completar los cambios.,
@@ -912,17 +934,32 @@ ClientCore/frmMainTemplate,Main Template Form,szResetDefaultTitle,Restablecer a 
 ClientCore/frmMainTemplate,Main Template Form,szRuleSets,Conjuntos de reglas,
 ClientCore/frmMainTemplate,Main Template Form,szRuleSetsAdded,Se importó %1 RuleSets del archivo de configuración '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szSavingConfiguration,Guardando configuración...,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledControlBlocked,Windows no puede enviar comandos de control al servicio — use Detener de nuevo para finalizar el proceso o compruebe services.msc,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledInProgress,El control del servicio no está disponible temporalmente,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNoAccess,No se puede controlar el servicio — ejecute el Configuration Client como administrador,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNotInstalled,El servicio de Windows no está instalado,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledOrphan,El proceso del servicio se ejecuta sin control del servicio de Windows — use Finalizar servicio en el menú Herramientas,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPaused,El servicio está en pausa (recargando configuración) — Detener y Reiniciar están deshabilitados hasta que termine la recarga,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPausing,El servicio se está pausando — espere,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledResuming,El servicio se está reanudando — espere,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStarting,El servicio se está iniciando — espere,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStopping,El servicio se está deteniendo — espere,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Reinicia el servicio en segundo plano,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Inicia el servicio en segundo plano,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Detiene el servicio en segundo plano,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Administración de servicios,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusControlBlocked,Servicio: Control no disponible,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Servicio: En pausa (Recargando),
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Servicio: Pausando,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusProcessWithoutService,Servicio: Proceso en ejecución sin servicio,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Servicio: Reanudando,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Servicio: En ejecución,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Servicio: Iniciando,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Servicio: Detenido,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Servicio: Deteniendo,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableAccessDenied,Servicio: No se puede consultar (acceso denegado),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableNotInstalled,Servicio: No instalado,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableWin32,Servicio: No disponible,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Servicio: Desconocido,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Servicios,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,Se importó %1 Services del archivo de configuración '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -766,6 +766,7 @@ ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceDisplayName.Text,NT-te
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceMonitor.Text,NT-teenuse monitor,
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceName.Text,NT-teenuse nimi,
 ClientCore/frmMainTemplate,Main Template Form,mnuNetworkDiscovery.Text,Võrgu avastamine,
+ClientCore/frmMainTemplate,Main Template Form,mnuOpenWindowsServices.Text,Ava Windowsi teenused,
 ClientCore/frmMainTemplate,Main Template Form,mnuOptions.Text,Valikud,
 ClientCore/frmMainTemplate,Main Template Form,mnuOtherServices.Text,Muud teenused,
 ClientCore/frmMainTemplate,Main Template Form,mnuPOP3Probe.Text,POP3 sond,
@@ -859,8 +860,19 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfiguration,Viga ko
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfigurationText,Konfiguratsiooni ei saanud salvestada:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Andmemuutujate salvestamine ebaõnnestus,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Andmemuutujate salvestamine ebaõnnestus järgmises kataloogis:,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlocked,Teenus ei aktsepteeri juhtimiskäske,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedMsg,"Windowsi viga 1061: Teenus ei saa praegu vastu võtta peatamise, käivitamise ega taaskäivitamise käske. Teenus võib olla hõivatud või ebaühtses olekus.
+
+Kas soovite taustateenuse protsessi sunniviisiliselt lõpetada? Salvestamata andmed võivad kaduda.",
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedNoProcessMsg,"Windowsi viga 1061: Teenus ei saa praegu juhtimiskäske vastu võtta.
+
+Taustateenuse protsessi ei leitud. Oodake ja kontrollige Windowsi teenuste konsooli (services.msc).",
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,Järgmisele teenusele ei ole reeglistikku määratud:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,Järgmine teenus ei tööta teie praeguse litsentsiga:,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePaused,Teenus laadib konfiguratsiooni uuesti,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePausedMsg,"Taustateenus on konfiguratsiooni uuesti laadimise ajal peatatud. Peata ja Taaskäivita on keelatud, sest need võivad teenuse ebastabiilseks muuta.
+
+Oodake, kuni olek naaseb Töötab olekusse.",
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Teenuse käivitamine võtab oodatust kauem aega,
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"Configuration Client lõpetas ootamise 30 sekundi järel. Taustateenus võib endiselt käivituda.
 
@@ -885,6 +897,16 @@ ClientCore/frmMainTemplate,Main Template Form,szImportingConfiguration,Konfigura
 ClientCore/frmMainTemplate,Main Template Form,szInitClient,Initsieeriv klient,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDef,Algkonfiguratsiooni määratlused,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDisplay,Init konfiguratsiooni kuva,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmMsg,See lõpetab taustateenuse protsessi sunniviisiliselt. Salvestamata andmed võivad kaduda. Kas jätkata?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmTitle,Kas lõpetada teenuse protsess?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailed,Teenuse protsessi ei saanud lõpetada,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailedMsg,"Configuration Client ei saanud taustateenuse protsessi lõpetada. Protsess võib olla kaitstud või klient võib vajada administraatori õigusi.
+
+Proovige uuesti tõstetud õigustega või lõpetage protsess Windowsi tegumihalduri või services.msc abil.",
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailed,Kõiki teenuse protsesse ei saanud lõpetada,
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailedMsg,"Vähemalt üks sobiv taustateenuse protsess lõpetati, kuid teine sobiv protsess töötab endiselt.
+
+Proovige uuesti tõstetud õigustega või lõpetage ülejäänud protsess Windowsi tegumihalduri või services.msc abil.",
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Keeleseadeid muudetud,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Olete muutnud keeleseadeid.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Muudatuste lõpuleviimiseks on vaja kliendirakendus uuesti laadida.,
@@ -912,17 +934,32 @@ ClientCore/frmMainTemplate,Main Template Form,szResetDefaultTitle,Lähtestage va
 ClientCore/frmMainTemplate,Main Template Form,szRuleSets,Reeglistikud,
 ClientCore/frmMainTemplate,Main Template Form,szRuleSetsAdded,Imporditud %1 reeglistikku konfiguratsioonifailist '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szSavingConfiguration,Seadistuse salvestamine ...,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledControlBlocked,"Windows ei saa praegu teenusele juhtimiskäske saata — kasutage uuesti Peata, et protsess lõpetada, või kontrollige services.msc",
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledInProgress,Teenuse juhtimine on ajutiselt kättesaamatu,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNoAccess,Teenust ei saa juhtida — proovige Configuration Clienti käivitada administraatorina,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNotInstalled,Windowsi teenus pole installitud,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledOrphan,Teenuse protsess töötab ilma Windowsi teenuse juhtimiseta — kasutage Tööriistad menüüs Lõpeta teenus,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPaused,Teenus on peatatud (konfiguratsiooni uuesti laadimine) — Peata ja Taaskäivita on keelatud kuni laadimine lõpeb,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPausing,Teenus peatatakse — palun oodake,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledResuming,Teenus jätkub — palun oodake,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStarting,Teenus käivitub — palun oodake,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStopping,Teenus peatub — palun oodake,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Restarts the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Starts the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Stops the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Teenuse haldus,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusControlBlocked,Teenus: juhtimine pole saadaval,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Teenus: peatatud (uuesti laadimine),
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Teenus: peatamise ootel,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusProcessWithoutService,Teenus: protsess töötab ilma teenuseta,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Teenus: jätkamine,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Teenus: töötab,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Teenus: käivitamine,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Teenus: peatatud,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Teenus: peatamine,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableAccessDenied,Teenus: päring ebaõnnestus (juurdepääs keelatud),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableNotInstalled,Teenus: pole installitud,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableWin32,Teenus: pole saadaval,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Teenus: teadmata,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Teenused,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,Imporditud %1 teenust konfiguratsioonifailist '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -766,6 +766,7 @@ ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceDisplayName.Text,Nom d
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceMonitor.Text,Moniteur de services NT,
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceName.Text,Nom du service NT,
 ClientCore/frmMainTemplate,Main Template Form,mnuNetworkDiscovery.Text,Découverte du réseau,
+ClientCore/frmMainTemplate,Main Template Form,mnuOpenWindowsServices.Text,Ouvrir les services Windows,
 ClientCore/frmMainTemplate,Main Template Form,mnuOptions.Text,Possibilités,
 ClientCore/frmMainTemplate,Main Template Form,mnuOtherServices.Text,Autres services,
 ClientCore/frmMainTemplate,Main Template Form,mnuPOP3Probe.Text,Sonde POP3,
@@ -859,8 +860,19 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfiguration,Erreur 
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfigurationText,La configuration n'a pas pu être enregistrée :,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Échec de l'enregistrement des variables de données,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Échec de l'enregistrement des variables de données pour le répertoire suivant :,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlocked,Le service n'accepte pas les commandes de contrôle,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedMsg,"Erreur Windows 1061 : Le service ne peut pas accepter les commandes d'arrêt, de démarrage ou de redémarrage pour le moment. Il peut être occupé ou dans un état incohérent.
+
+Voulez-vous arrêter de force le processus du service en arrière-plan ? Des données non enregistrées peuvent être perdues.",
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedNoProcessMsg,"Erreur Windows 1061 : Le service ne peut pas accepter de commandes de contrôle pour le moment.
+
+Aucun processus de service en arrière-plan n'a été trouvé. Veuillez patienter et vérifier la console des services Windows (services.msc).",
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,Le service suivant n'a aucun RuleSet attribué :,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,Le service suivant ne fonctionnera pas avec votre licence actuelle :,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePaused,Le service recharge la configuration,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePausedMsg,"Le service en arrière-plan est en pause pendant le rechargement de la configuration. Arrêter et Redémarrer sont désactivés car ils peuvent rendre le service instable.
+
+Veuillez patienter jusqu'à ce que l'état revienne à En cours d'exécution.",
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,Le démarrage du service prend plus de temps que prévu,
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"Le Configuration Client a cessé d'attendre après 30 secondes. Le service en arrière-plan peut encore être en cours de démarrage.
 
@@ -885,6 +897,16 @@ ClientCore/frmMainTemplate,Main Template Form,szImportingConfiguration,Importati
 ClientCore/frmMainTemplate,Main Template Form,szInitClient,Client initial,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDef,Définitions de configuration d'initialisation,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDisplay,Affichage de la configuration d'initialisation,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmMsg,Le processus du service en arrière-plan sera arrêté de force. Des données non enregistrées peuvent être perdues. Continuer ?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmTitle,Terminer le processus du service ?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailed,Impossible de terminer le processus du service,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailedMsg,"Le Configuration Client n'a pas pu terminer le processus du service en arrière-plan. Le processus peut être protégé ou le client doit peut-être être exécuté en tant qu'administrateur.
+
+Réessayez avec des droits élevés ou terminez le processus via le Gestionnaire des tâches Windows ou services.msc.",
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailed,Impossible de terminer tous les processus du service,
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailedMsg,"Au moins un processus de service en arrière-plan correspondant a été terminé, mais un autre processus correspondant est encore en cours d'exécution.
+
+Réessayez avec des droits élevés ou terminez le processus restant via le Gestionnaire des tâches Windows ou services.msc.",
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Paramètres de langue modifiés,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Vous avez modifié les paramètres de langue.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Un rechargement de l'application Client est nécessaire pour finaliser les modifications.,
@@ -912,17 +934,32 @@ ClientCore/frmMainTemplate,Main Template Form,szResetDefaultTitle,Réinitialiser
 ClientCore/frmMainTemplate,Main Template Form,szRuleSets,RuleSets,
 ClientCore/frmMainTemplate,Main Template Form,szRuleSetsAdded,RuleSets %1 importés à partir du fichier de configuration '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szSavingConfiguration,Sauvegarde de la configuration...,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledControlBlocked,Windows ne peut pas envoyer de commandes de contrôle au service — utilisez à nouveau Arrêter pour tuer le processus ou vérifiez services.msc,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledInProgress,Le contrôle du service est temporairement indisponible,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNoAccess,Impossible de contrôler le service — exécutez le Configuration Client en tant qu'administrateur,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNotInstalled,Le service Windows n'est pas installé,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledOrphan,Le processus du service s'exécute sans contrôle du service Windows — utilisez Arrêter le service dans le menu Outils,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPaused,Le service est en pause (rechargement de la configuration) — Arrêter et Redémarrer sont désactivés jusqu'à la fin du rechargement,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPausing,Le service se met en pause — veuillez patienter,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledResuming,Le service reprend — veuillez patienter,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStarting,Le service démarre — veuillez patienter,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStopping,Le service s'arrête — veuillez patienter,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Redémarre le service en arrière-plan,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Démarre le service en arrière-plan,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Arrête le service en arrière-plan,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Gestion des services,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusControlBlocked,Service : Contrôle indisponible,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Service : En pause (Rechargement),
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Service : Mise en pause,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusProcessWithoutService,Service : Processus en cours sans service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Service : Reprise en cours,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Service : En cours d'exécution,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Service : Démarrage en cours,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Service : Arrêté,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Service : Arrêt en cours,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableAccessDenied,Service : Interrogation impossible (accès refusé),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableNotInstalled,Service : Non installé,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableWin32,Service : Indisponible,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Service : Inconnu,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Services,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,Services %1 importés à partir du fichier de configuration '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -766,6 +766,7 @@ ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceDisplayName.Text,Nome 
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceMonitor.Text,Monitor servizio NT,
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceName.Text,Nome del servizio NT,
 ClientCore/frmMainTemplate,Main Template Form,mnuNetworkDiscovery.Text,Scoperta della rete,
+ClientCore/frmMainTemplate,Main Template Form,mnuOpenWindowsServices.Text,Apri servizi Windows,
 ClientCore/frmMainTemplate,Main Template Form,mnuOptions.Text,Opzioni,
 ClientCore/frmMainTemplate,Main Template Form,mnuOtherServices.Text,Servizi aggiuntivi,
 ClientCore/frmMainTemplate,Main Template Form,mnuPOP3Probe.Text,POP3 Probe,
@@ -859,8 +860,19 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfiguration,Errore 
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfigurationText,Impossibile salvare la configurazione:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Impossibile salvare le variabili dei dati,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Il salvataggio delle variabili di dati non è riuscito per la seguente directory:,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlocked,Il servizio non accetta comandi di controllo,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedMsg,"Errore Windows 1061: Il servizio non può accettare comandi di arresto, avvio o riavvio in questo momento. Potrebbe essere occupato o in uno stato incoerente.
+
+Terminare forzatamente il processo del servizio in background? I dati non salvati potrebbero andare persi.",
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedNoProcessMsg,"Errore Windows 1061: Il servizio non può accettare comandi di controllo in questo momento.
+
+Nessun processo del servizio in background trovato. Attendere e controllare la console Servizi di Windows (services.msc).",
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,Al seguente servizio non è assegnato alcun set di regole:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,Il seguente servizio non funzionerà con la licenza attuale:,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePaused,Il servizio sta ricaricando la configurazione,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePausedMsg,"Il servizio in background è in pausa durante il ricaricamento della configurazione. Arresta e Riavvia sono disabilitati perché possono rendere il servizio instabile.
+
+Attendere che lo stato torni a In esecuzione.",
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,L'avvio del servizio sta richiedendo più tempo del previsto,
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"Il Configuration Client ha interrotto l'attesa dopo 30 secondi. Il servizio in background potrebbe essere ancora in avvio.
 
@@ -885,6 +897,16 @@ ClientCore/frmMainTemplate,Main Template Form,szImportingConfiguration,Importazi
 ClientCore/frmMainTemplate,Main Template Form,szInitClient,Cliente Iniziatore,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDef,Definizioni di configurazione inizializzazione,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDisplay,Visualizzazione della configurazione iniziale,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmMsg,Il processo del servizio in background verrà terminato forzatamente. I dati non salvati potrebbero andare persi. Continuare?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmTitle,Terminare il processo del servizio?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailed,Impossibile terminare il processo del servizio,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailedMsg,"Il Configuration Client non ha potuto terminare il processo del servizio in background. Il processo potrebbe essere protetto o il client potrebbe richiedere diritti di amministratore.
+
+Riprovare con privilegi elevati oppure terminare il processo tramite Gestione attività di Windows o services.msc.",
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailed,Impossibile terminare tutti i processi del servizio,
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailedMsg,"Almeno un processo di servizio in background corrispondente è stato terminato, ma un altro processo corrispondente è ancora in esecuzione.
+
+Riprovare con privilegi elevati oppure terminare il processo rimanente tramite Gestione attività di Windows o services.msc.",
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Le impostazioni della lingua sono cambiate,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Hai cambiato le impostazioni della lingua.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Per completare le modifiche è necessario ricaricare l'applicazione Client.,
@@ -912,17 +934,32 @@ ClientCore/frmMainTemplate,Main Template Form,szResetDefaultTitle,Ripristina le 
 ClientCore/frmMainTemplate,Main Template Form,szRuleSets,Set di regole,
 ClientCore/frmMainTemplate,Main Template Form,szRuleSetsAdded,%1 set di regole importati dal file di configurazione '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szSavingConfiguration,Salvataggio della configurazione...,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledControlBlocked,Windows non può inviare comandi di controllo al servizio — usare di nuovo Arresta per terminare il processo o controllare services.msc,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledInProgress,Il controllo del servizio è temporaneamente non disponibile,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNoAccess,Impossibile controllare il servizio — avviare il Configuration Client come amministratore,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNotInstalled,Il servizio Windows non è installato,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledOrphan,Il processo del servizio è in esecuzione senza controllo del servizio Windows — usare Termina servizio nel menu Strumenti,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPaused,Il servizio è in pausa (ricaricamento configurazione) — Arresta e Riavvia sono disabilitati fino al completamento del ricaricamento,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPausing,Il servizio si sta mettendo in pausa — attendere,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledResuming,Il servizio sta riprendendo — attendere,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStarting,Il servizio si sta avviando — attendere,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStopping,Il servizio si sta arrestando — attendere,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Restarts the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Starts the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Stops the Background Service,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Gestione dei servizi,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusControlBlocked,Servizio: Controllo non disponibile,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Servizio: in pausa (Ricaricamento),
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Servizio: pausa in corso,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusProcessWithoutService,Servizio: Processo in esecuzione senza servizio,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Servizio: ripresa in corso,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Servizio: in esecuzione,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Servizio: in avvio,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Servizio: arrestato,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Servizio: in arresto,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableAccessDenied,Servizio: Impossibile interrogare (accesso negato),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableNotInstalled,Servizio: Non installato,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableWin32,Servizio: Non disponibile,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Servizio: sconosciuto,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Servizi,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,%1 servizi importati dal file di configurazione '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -762,6 +762,7 @@ ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceDisplayName.Text,NT �
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceMonitor.Text,NT サービス モニタ,
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceName.Text,NT サービス名,
 ClientCore/frmMainTemplate,Main Template Form,mnuNetworkDiscovery.Text,ネットワークの検出,
+ClientCore/frmMainTemplate,Main Template Form,mnuOpenWindowsServices.Text,Windows サービスを開く,
 ClientCore/frmMainTemplate,Main Template Form,mnuOptions.Text,オプション,
 ClientCore/frmMainTemplate,Main Template Form,mnuOtherServices.Text,その他のサービス,
 ClientCore/frmMainTemplate,Main Template Form,mnuPOP3Probe.Text,POP3 探査,
@@ -855,8 +856,19 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfiguration,設定�
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfigurationText,設定が保存できませんでした: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,データ変数の保存に失敗しました,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,以下のディレクトリでデータ変数の保存に失敗しました: ,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlocked,サービスは制御コマンドを受け付けません,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedMsg,"Windows エラー 1061: サービスは現在、停止、開始、または再起動のコマンドを受け付けできません。サービスがビジー状態であるか、不整合な状態にある可能性があります。
+
+バックグラウンド サービス プロセスを強制終了しますか? 未保存のデータが失われる場合があります。",
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedNoProcessMsg,"Windows エラー 1061: サービスは現在、制御コマンドを受け付けできません。
+
+バックグラウンド サービス プロセスが見つかりませんでした。しばらく待ってから Windows サービス コンソール (services.msc) を確認してください。",
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,以下のサービスはルールセットが設定されていません: ,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,このサービスはお持ちのライセンスでは使用できません:,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePaused,サービスは設定を再読み込み中です,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePausedMsg,"バックグラウンド サービスは設定を再読み込み中のため一時停止しています。[停止] と [再起動] は、サービスが不安定になる可能性があるため現在使用できません。
+
+ステータスが [実行中] に戻るまでお待ちください。",
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,サービスの開始に予想より時間がかかっています,
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"30秒経過後、Configuration Clientは待機を終了しました。バックグラウンド サービスはまだ開始中の可能性があります。
 
@@ -881,6 +893,16 @@ ClientCore/frmMainTemplate,Main Template Form,szImportingConfiguration,Importing
 ClientCore/frmMainTemplate,Main Template Form,szInitClient,クライアントを起動,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDef,Init 設定の定義,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDisplay,Init 設定の表示,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmMsg,バックグラウンド サービス プロセスを強制終了します。未保存のデータが失われる場合があります。続行しますか?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmTitle,サービス プロセスを強制終了しますか?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailed,サービス プロセスを強制終了できませんでした,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailedMsg,"Configuration Client はバックグラウンド サービス プロセスを終了できませんでした。プロセスが保護されているか、管理者として実行する必要がある可能性があります。
+
+昇格したセッションで再試行するか、Windows タスク マネージャーまたは services.msc でプロセスを終了してください。",
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailed,すべてのサービス プロセスを強制終了できませんでした,
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailedMsg,"一致するバックグラウンド サービス プロセスの少なくとも 1 つは終了しましたが、別の一致するプロセスがまだ実行中です。
+
+昇格したセッションで再試行するか、Windows タスク マネージャーまたは services.msc で残りのプロセスを終了してください。",
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,言語が変更されました,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,言語を変更しますか？,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,変更するにはクライアントをリロードする必要があります,
@@ -908,17 +930,32 @@ ClientCore/frmMainTemplate,Main Template Form,szResetDefaultTitle,デフォル�
 ClientCore/frmMainTemplate,Main Template Form,szRuleSets,ルールセット,
 ClientCore/frmMainTemplate,Main Template Form,szRuleSetsAdded,ルールセット %1 を設定ファイル '%2' からインポートしました,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szSavingConfiguration,設定を保存しています ...,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledControlBlocked,Windows は現在サービス制御コマンドを送信できません — もう一度 [停止] でプロセスを終了するか、services.msc を確認してください,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledInProgress,サービス制御は一時的に利用できません,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNoAccess,サービスを制御できません — Configuration Client を管理者として実行してください,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNotInstalled,Windows サービスがインストールされていません,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledOrphan,サービス プロセスが Windows サービス制御なしで実行中です — [ツール] メニューの [サービスを強制終了] を使用してください,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPaused,サービスは一時停止中 (設定を再読み込み中) — 再読み込みが完了するまで [停止] と [再起動] は無効です,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPausing,サービスを一時停止しています — お待ちください,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledResuming,サービスを再開しています — お待ちください,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStarting,サービスを開始しています — お待ちください,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStopping,サービスを停止しています — お待ちください,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,バックグラウンド サービスを再起動します,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,バックグラウンド サービスを開始します,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,バックグラウンド サービスを停止します,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,サービス管理,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusControlBlocked,サービス: 制御不可,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,サービス: 一時停止 (再読み込み中),
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,サービス: 一時停止中,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusProcessWithoutService,サービス: サービスなしでプロセスが実行中,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,サービス: 再開中,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,サービス: 実行中,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,サービス: 開始中,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,サービス: 停止,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,サービス: 停止中,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableAccessDenied,サービス: 照会できません (アクセス拒否),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableNotInstalled,サービス: 未インストール,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableWin32,サービス: 利用不可,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,サービス: 不明,
 ClientCore/frmMainTemplate,Main Template Form,szServices,サービス,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,サービス %1 を設定ファイル '%2' からインポートしました,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -765,6 +765,7 @@ ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceDisplayName.Text,Nome 
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceMonitor.Text,Monitor de serviço NT,
 ClientCore/frmMainTemplate,Main Template Form,mnuNTServiceName.Text,Nome do serviço NT,
 ClientCore/frmMainTemplate,Main Template Form,mnuNetworkDiscovery.Text,Descoberta de rede,
+ClientCore/frmMainTemplate,Main Template Form,mnuOpenWindowsServices.Text,Abrir serviços do Windows,
 ClientCore/frmMainTemplate,Main Template Form,mnuOptions.Text,Opções,
 ClientCore/frmMainTemplate,Main Template Form,mnuOtherServices.Text,Outros serviços,
 ClientCore/frmMainTemplate,Main Template Form,mnuPOP3Probe.Text,POP3 Probe,
@@ -858,8 +859,19 @@ ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfiguration,Erro ao
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingConfigurationText,A configuração não pôde ser salva:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingData,Falha ao salvar variáveis ​​de dados,
 ClientCore/frmMainTemplate,Main Template Form,szErrorSavingDataText,Falha ao salvar variáveis ​​de dados para o seguinte diretório:,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlocked,O serviço não aceita comandos de controle,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedMsg,"Erro do Windows 1061: O serviço não pode aceitar comandos de parar, iniciar ou reiniciar no momento. Ele pode estar ocupado ou em um estado inconsistente.
+
+Deseja encerrar à força o processo do serviço em segundo plano? Dados não salvos podem ser perdidos.",
+ClientCore/frmMainTemplate,Main Template Form,szErrorServiceControlBlockedNoProcessMsg,"Erro do Windows 1061: O serviço não pode aceitar comandos de controle no momento.
+
+Nenhum processo do serviço em segundo plano foi encontrado. Aguarde e verifique o console de Serviços do Windows (services.msc).",
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNoRuleSet,O serviço a seguir não tem conjunto de regras atribuído:,
 ClientCore/frmMainTemplate,Main Template Form,szErrorServiceNotLicensed,O serviço a seguir não funcionará com sua licença atual:,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePaused,O serviço está recarregando a configuração,
+ClientCore/frmMainTemplate,Main Template Form,szErrorServicePausedMsg,"O serviço em segundo plano está pausado enquanto recarrega a configuração. Parar e Reiniciar estão desabilitados porque podem deixar o serviço instável.
+
+Aguarde até o status voltar a Em execução.",
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingService,A inicialização do serviço está demorando mais do que o esperado,
 ClientCore/frmMainTemplate,Main Template Form,szErrorStartingServiceMsg,"O Configuration Client parou de aguardar após 30 segundos. O serviço em segundo plano ainda pode estar iniciando.
 
@@ -884,6 +896,16 @@ ClientCore/frmMainTemplate,Main Template Form,szImportingConfiguration,Importand
 ClientCore/frmMainTemplate,Main Template Form,szInitClient,Iniciando Cliente,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDef,Definições de configuração de inicialização,
 ClientCore/frmMainTemplate,Main Template Form,szInitConfigDisplay,Exibição de configuração inicial,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmMsg,O processo do serviço em segundo plano será encerrado à força. Dados não salvos podem ser perdidos. Continuar?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceConfirmTitle,Encerrar o processo do serviço?,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailed,Não foi possível encerrar o processo do serviço,
+ClientCore/frmMainTemplate,Main Template Form,szKillServiceFailedMsg,"O Configuration Client não pôde encerrar o processo do serviço em segundo plano. O processo pode estar protegido ou o cliente pode precisar ser executado como administrador.
+
+Tente novamente com privilégios elevados ou encerre o processo pelo Gerenciador de Tarefas do Windows ou services.msc.",
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailed,Não foi possível encerrar todos os processos do serviço,
+ClientCore/frmMainTemplate,Main Template Form,szKillServicePartialFailedMsg,"Pelo menos um processo correspondente do serviço em segundo plano foi encerrado, mas outro processo correspondente ainda está em execução.
+
+Tente novamente com privilégios elevados ou encerre o processo restante pelo Gerenciador de Tarefas do Windows ou services.msc.",
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Configurações de idioma alteradas,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Você alterou as configurações de idioma.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,É necessário recarregar o aplicativo Cliente para concluir as alterações.,
@@ -911,17 +933,32 @@ ClientCore/frmMainTemplate,Main Template Form,szResetDefaultTitle,Redefinir para
 ClientCore/frmMainTemplate,Main Template Form,szRuleSets,Conjuntos de regras,
 ClientCore/frmMainTemplate,Main Template Form,szRuleSetsAdded,%1 conjuntos de regras importados do arquivo de configuração '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szSavingConfiguration,Salvando configuração...,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledControlBlocked,O Windows não pode enviar comandos de controle ao serviço — use Parar novamente para encerrar o processo ou verifique services.msc,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledInProgress,O controle do serviço está temporariamente indisponível,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNoAccess,Não é possível controlar o serviço — execute o Configuration Client como administrador,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledNotInstalled,O serviço do Windows não está instalado,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledOrphan,O processo do serviço está em execução sem controle do serviço do Windows — use Encerrar serviço no menu Ferramentas,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPaused,O serviço está pausado (recarregando configuração) — Parar e Reiniciar estão desabilitados até a recarga terminar,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledPausing,O serviço está pausando — aguarde,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledResuming,O serviço está retomando — aguarde,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStarting,O serviço está iniciando — aguarde,
+ClientCore/frmMainTemplate,Main Template Form,szServiceButtonDisabledStopping,O serviço está parando — aguarde,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintRestart,Reinicia o serviço em segundo plano,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStart,Inicia o serviço em segundo plano,
 ClientCore/frmMainTemplate,Main Template Form,szServiceButtonHintStop,Para o serviço em segundo plano,
 ClientCore/frmMainTemplate,Main Template Form,szServiceEvents,Gerenciamento de serviços,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusControlBlocked,Serviço: Controle indisponível,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPaused,Serviço: em pausa (Recarregando),
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusPausing,Serviço: pausando,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusProcessWithoutService,Serviço: Processo em execução sem serviço,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusResuming,Serviço: retomando,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusRunning,Serviço: em execução,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStarting,Serviço: iniciando,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopped,Serviço: parado,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusStopping,Serviço: parando,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableAccessDenied,Serviço: Não é possível consultar (acesso negado),
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableNotInstalled,Serviço: Não instalado,
+ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnavailableWin32,Serviço: Indisponível,
 ClientCore/frmMainTemplate,Main Template Form,szServiceStatusUnknown,Serviço: desconhecido,
 ClientCore/frmMainTemplate,Main Template Form,szServices,Serviços,
 ClientCore/frmMainTemplate,Main Template Form,szServicesAdded,%1 serviços importados do arquivo de configuração '%2'.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: 7feb5f3457f0fbe78900f66e4a4a747c293e14c4
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new service management texts to client language CSVs and adds the “Open Windows Services” menu item across 8 locales. Improves clarity for service control errors, paused states, and button hints.

- **New Features**
  - Added `mnuOpenWindowsServices` label in de-DE, en-US, es-ES, et-EE, fr-FR, it-IT, ja-JP, pt-BR.
  - New messages for Windows error 1061, paused/reloading config, process without service.
  - Added kill service flow: confirm, partial/failure messages, and guidance to use Task Manager or services.msc.
  - Button disabled hints for blocked control, in-progress states, no access, not installed, orphan process.
  - New status variants: control unavailable, access denied, not installed, unavailable.
  - CSV keys/structure unchanged; protected product names preserved; placeholders like %1/%2 kept exact.

<sup>Written for commit 9747380de9642af921f6c6f42e184dbe1f8e09a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

