### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -1572,6 +1572,8 @@ ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueBody
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueLable,Queue Nachricht Label,
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueName,Queuename,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpSendPort,RELP Port,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize,RELP-Fenstergröße,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize.tooltip,0 oder 1 = Bibliotheksstandard (128 unbestätigte Frames). Werte größer als 1 setzen ein explizites RELP-Client-Fenster vor dem Verbindungsaufbau (maximal 4096).,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSendTimeOut,Send /Receive Timeout,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nTimeOutSession,Sitzungs-Timeout,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nUseSSL,SSL/TLS Verschlüsselung aktivieren.,

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -1576,6 +1576,8 @@ ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueBody
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueLable,Queue Message Label,
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueName,Queuename,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpSendPort,RELP Port,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize,RELP Window Size,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize.tooltip,0 or 1 = library default (128 unacked frames). Values greater than 1 set an explicit RELP client window before connect (maximum 4096).,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSendTimeOut,Send /Receive Timeout,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nTimeOutSession,Session Timeout,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nUseSSL,Enable SSL / TLS Encryption.,

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -1572,6 +1572,8 @@ ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueBody
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueLable,Etiqueta de mensaje en cola,
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueName,nombre de cola,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpSendPort,Puerto RELP,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize,Tamaño de ventana RELP,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize.tooltip,0 o 1 = valor predeterminado de la biblioteca (128 tramas sin confirmar). Los valores superiores a 1 establecen una ventana RELP explícita antes de conectar (máximo 4096).,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSendTimeOut,Tiempo de espera de envío/recepción,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nTimeOutSession,Tiempo de espera de sesión,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nUseSSL,Habilitar cifrado SSL/TLS.,

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -1576,6 +1576,8 @@ ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueBody
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueLable,Järjekorra sõnumi silt,
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueName,Järjekorranimi,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpSendPort,RELP Port,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize,RELP akna suurus,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize.tooltip,0 või 1 = teegi vaikimisi (128 kinnitamata kaadrit). Väärtused üle 1 määravad enne ühendamist selge RELP kliendi akna (maksimum 4096).,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSendTimeOut,Saatmise/vastuvõtmise ajalõpp,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nTimeOutSession,Seansi ajalõpp,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nUseSSL,Luba SSL/TLS-krüptimine.,

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -1576,6 +1576,8 @@ ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueBody
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueLable,Étiquette de message de file d'attente,
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueName,Nom de la file d'attente,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpSendPort,Port RELP,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize,Taille de fenêtre RELP,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize.tooltip,0 ou 1 = valeur par défaut de la bibliothèque (128 trames non acquittées). Les valeurs supérieures à 1 définissent une fenêtre RELP explicite avant la connexion (maximum 4096).,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSendTimeOut,Délai d'envoi/réception,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nTimeOutSession,Expiration de la session,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nUseSSL,Activez le cryptage SSL/TLS.,

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -1576,6 +1576,8 @@ ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueBody
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueLable,Etichetta del messaggio in coda,
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueName,Nome coda,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpSendPort,RELP Porta,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize,Dimensione finestra RELP,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize.tooltip,0 o 1 = predefinito della libreria (128 frame non confermati). Valori superiori a 1 impostano una finestra RELP esplicita prima della connessione (massimo 4096).,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSendTimeOut,Timeout invio/ricezione,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nTimeOutSession,Timeout della sessione,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nUseSSL,Abilita la crittografia SSL/TLS.,

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -1577,6 +1577,8 @@ ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueBody
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueLable,キューのメッセージラベル,
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueName,キュー名,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpSendPort,RELP ポート,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize,RELP ウィンドウサイズ,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize.tooltip,0 または 1 = ライブラリのデフォルト（未確認フレーム 128）。1 より大きい値は接続前に明示的な RELP ウィンドウを設定します（最大 4096）。,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSendTimeOut,送信/受信 タイムアウト,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nTimeOutSession,セッションタイムアウト,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nUseSSL,SSL/TLSを使用,

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -1575,6 +1575,8 @@ ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueBody
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueLable,Etiqueta de mensagem da fila,
 ClientCore/xml.languagefiles/Action.SendMSQueue,Send MS Queue Action,szQueueName,Nome da fila,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpSendPort,Porta RELP,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize,Tamanho da janela RELP,
+ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSelpWindowSize.tooltip,0 ou 1 = padrão da biblioteca (128 quadros não confirmados). Valores maiores que 1 definem uma janela RELP explícita antes da conexão (máximo 4096).,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nSendTimeOut,Tempo limite de envio/recebimento,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nTimeOutSession,Tempo limite da sessão,
 ClientCore/xml.languagefiles/Action.SendRelp,Send Relp Action,nUseSSL,Ative a criptografia SSL/TLS.,


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: c1754472c82f6010186885418fe15383f5ba7fa3
Trigger: push