### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -983,6 +983,8 @@ Ihre Konfiguration wird zwar gesichert, aber die Anwendung benötigt eine gülti
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfiguration,Warning beim speichern der Konfiguration,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationBackup,Fehler beim sichern der alten Konfigurationsdatei. Speichern der Konfiguration in die folgende Datei könnte fehlschlagen: ,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationOldFile,Fehler beim löschen einer alten Konfigurationsdatei. Die Datei ist wahrscheinlich von einem anderen Programm geöffnet. Sie werden die folgende Datei von Hand löschen müssen: ,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItems,Unbekannte Konfigurationselemente,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItemsText,"Diese Konfiguration enthält Elemente, die von dieser Client-Version nicht unterstützt werden. Sie wurden beim Laden übersprungen. Wenn Sie die Konfiguration mit diesem Client speichern, gehen diese Elemente verloren. Wir empfehlen, die Konfigurationsdatei vor dem Speichern zu sichern.",
 ClientCore/frmMainTemplate,Main Template Form,tABToolStripMenuItem.Text,TAB,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items,Enabled,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items1,Disabled,

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -987,6 +987,8 @@ The configuration will be saved but the application needs to be licensed in orde
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfiguration,Warning while saving Configuration,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationBackup,Failed to backup old configuration file. Saving the configuration into the following file may fail: ,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationOldFile,Failed to delete an old configuration file. The file maybe blocked by another process. You will have to manually delete the following file: ,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItems,Unknown Configuration Items,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItemsText,"This configuration contains items that are not supported by this client version. They were skipped during load. If you save the configuration with this client, those items will be lost. We recommend backing up the configuration file before saving.",
 ClientCore/frmMainTemplate,Main Template Form,tABToolStripMenuItem.Text,TAB,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items,Enabled,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items1,Disabled,

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -987,6 +987,8 @@ La configuración se guardará pero la aplicación debe estar licenciada para se
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfiguration,Advertencia al guardar la configuración,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationBackup,Error al crear copia de seguridad del archivo de configuración anterior. Guardar la configuración en el siguiente archivo puede fallar: ,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationOldFile,Error al eliminar un archivo de configuración anterior. El archivo puede estar bloqueado por otro proceso. Deberá eliminar manualmente el siguiente archivo: ,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItems,Elementos de configuración desconocidos,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItemsText,"Esta configuración contiene elementos que no son compatibles con esta versión del cliente. Se omitieron durante la carga. Si guarda la configuración con este cliente, esos elementos se perderán. Recomendamos hacer una copia de seguridad del archivo de configuración antes de guardar.",
 ClientCore/frmMainTemplate,Main Template Form,tABToolStripMenuItem.Text,TAB,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items,Enabled,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items1,Disabled,

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -987,6 +987,8 @@ Konfiguratsioon salvestatakse, kuid rakendus peab töö jätkamiseks olema litse
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfiguration,Hoiatus konfiguratsiooni salvestamisel,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationBackup,Vana konfiguratsioonifaili varundamine ebaõnnestus. Konfiguratsiooni salvestamine järgmisse faili võib ebaõnnestuda:,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationOldFile,Vana konfiguratsioonifaili kustutamine ebaõnnestus. Fail võib olla blokeeritud mõne muu protsessi poolt. Peate järgmise faili käsitsi kustutama:,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItems,Tundmatud konfiguratsiooniüksused,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItemsText,"Selles konfiguratsioonis on üksusi, mida see kliendiversioon ei toeta. Need jäeti laadimisel vahele. Kui salvestate konfiguratsiooni selle kliendiga, need üksused kaovad. Soovitame enne salvestamist konfiguratsioonifailist varukoopia teha.",
 ClientCore/frmMainTemplate,Main Template Form,tABToolStripMenuItem.Text,TAB,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items,Enabled,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items1,Disabled,

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -987,6 +987,8 @@ La configuration sera enregistrée mais l'application doit disposer d'une licenc
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfiguration,Avertissement lors de l'enregistrement de la configuration,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationBackup,Échec de la sauvegarde de l'ancien fichier de configuration. L'enregistrement de la configuration dans le fichier suivant peut échouer :,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationOldFile,Échec de la suppression d'un ancien fichier de configuration. Le fichier est peut-être bloqué par un autre processus. Vous devrez supprimer manuellement le fichier suivant :,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItems,Éléments de configuration inconnus,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItemsText,"Cette configuration contient des éléments non pris en charge par cette version du client. Ils ont été ignorés lors du chargement. Si vous enregistrez la configuration avec ce client, ces éléments seront perdus. Nous recommandons de sauvegarder le fichier de configuration avant d'enregistrer.",
 ClientCore/frmMainTemplate,Main Template Form,tABToolStripMenuItem.Text,TAB,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items,Enabled,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items1,Disabled,

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -987,6 +987,8 @@ La configurazione verrà salvata ma l'applicazione dovrà disporre di una licenz
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfiguration,Avviso durante il salvataggio della configurazione,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationBackup,Impossibile eseguire il backup del vecchio file di configurazione. Il salvataggio della configurazione nel seguente file potrebbe non riuscire:,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationOldFile,Impossibile eliminare un vecchio file di configurazione. Il file potrebbe essere bloccato da un altro processo. Dovrai eliminare manualmente il seguente file:,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItems,Elementi di configurazione sconosciuti,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItemsText,"Questa configurazione contiene elementi non supportati da questa versione del client. Sono stati ignorati durante il caricamento. Se si salva la configurazione con questo client, tali elementi andranno persi. Si consiglia di eseguire il backup del file di configurazione prima di salvare.",
 ClientCore/frmMainTemplate,Main Template Form,tABToolStripMenuItem.Text,TAB,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items,Enabled,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items1,Disabled,

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -983,6 +983,8 @@ ClientCore/frmMainTemplate,Main Template Form,szWarnTrialExpired,"試用期間�
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfiguration,設定保存に関する警告,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationBackup,古い設定ファイルのバックアップに失敗しました。以下のファイルへの設定保存に失敗した可能性があります：,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationOldFile,古い設定ファイルの削除に失敗しました。そのファイルは他のプロセスによりブロックされているようです。以下のファイルは手動で削除してください：,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItems,不明な設定項目,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItemsText,この設定には、このクライアント版でサポートされていない項目が含まれています。読み込み時にスキップされました。このクライアントで設定を保存すると、これらの項目は失われます。保存する前に設定ファイルのバックアップを取ることをお勧めします。,
 ClientCore/frmMainTemplate,Main Template Form,tABToolStripMenuItem.Text,TAB,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items,Enabled,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items1,Disabled,

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -986,6 +986,8 @@ A configuração será salva, mas o aplicativo precisa ser licenciado para conti
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfiguration,Aviso ao salvar a configuração,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationBackup,Falha ao fazer backup do arquivo de configuração antigo. Salvar a configuração no seguinte arquivo pode falhar:,
 ClientCore/frmMainTemplate,Main Template Form,szWarningSavingConfigurationOldFile,Falha ao excluir um arquivo de configuração antigo. O arquivo pode estar bloqueado por outro processo. Você terá que excluir manualmente o seguinte arquivo:,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItems,Itens de configuração desconhecidos,
+ClientCore/frmMainTemplate,Main Template Form,szWarningUnknownConfigItemsText,"Esta configuração contém itens não suportados por esta versão do cliente. Eles foram ignorados durante o carregamento. Se você salvar a configuração com este cliente, esses itens serão perdidos. Recomendamos fazer backup do arquivo de configuração antes de salvar.",
 ClientCore/frmMainTemplate,Main Template Form,tABToolStripMenuItem.Text,TAB,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items,Enabled,
 ClientCore/frmMainTemplate,Main Template Form,tbCbEnabled.Items1,Disabled,


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: 76e09ec54addacd4c46a151af051e84c6f1f49a3
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds localized warning strings to the client language CSVs to alert users about unsupported configuration items and recommend backing up before saving. Improves clarity when older configs are opened in newer clients.

- New Features
  - Added `szWarningUnknownConfigItems` and `szWarningUnknownConfigItemsText` across de-DE, en-US, es-ES, et-EE, fr-FR, it-IT, ja-JP, and pt-BR.
  - CSV keys and structure remain unchanged; only translation values were added.

<sup>Written for commit febb48dc2cb676f5a09d94edc95a836abb8f3e37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

