### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -921,6 +921,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Wollen Sie 
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"Der Lizenzschlüssel ist für dieses Produkt ungültig. Er kann falsch eingegeben sein, nicht zum Lizenznamen passen oder beschädigt sein. Prüfen Sie die Einstellungen unter Allgemein.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,"Dieser Lizenzschlüssel ist für diese Produktversion ungültig (falsche Release- bzw. Hauptversion). Sie benötigen einen Schlüssel, der zu diesem Build passt. Aktualisieren Sie die Lizenz unter Allgemein.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Es ist kein Lizenzschlüssel hinterlegt (Lizenzname oder Hauptschlüssel fehlt). Geben Sie Ihre Lizenz unter Allgemein ein oder aktualisieren Sie sie.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,"Es ist keine gültige Lizenzdatei konfiguriert. Verwenden Sie die Registerkarte „Lizenzdatei“ unter Allgemein, um eine .alic-Lizenzdatei anzugeben oder bereitzustellen.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Keine gültige Lizenzdatei konfiguriert,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Lizenzdatei gültig,

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -925,6 +925,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Do you want
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"The license key is not valid for this product. It may be mistyped, not match the license name, or be corrupted. Check General settings.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,This license key is not valid for this version of the product (wrong release / major version). You need a key that matches this build. Update your license in General settings.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,No license key is configured (license name or primary key is missing). Enter or update your license in General settings.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,No valid license file is configured. Use the License File tab under General settings to specify or deploy a .alic license file.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,No valid license file configured,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,License file valid,

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -925,6 +925,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,¿Desea rei
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La clave de licencia no es válida para este producto. Puede estar mal escrita, no coincidir con el nombre de licencia o estar corrupta. Revise la configuración general.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Esta clave de licencia no es válida para esta versión del producto (versión o release incorrecta). Necesita una clave que corresponda a esta compilación. Actualice la licencia en la configuración general.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,No hay clave de licencia configurada (falta el nombre de licencia o la clave principal). Introduzca o actualice su licencia en la configuración general.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,No hay ningún archivo de licencia válido configurado. Use la pestaña Archivo de licencia en Configuración general para especificar o implementar un archivo de licencia .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,No hay un archivo de licencia válido configurado,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Archivo de licencia válido,

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -925,6 +925,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Kas soovite
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"Litsentsivõti ei kehti selle toote jaoks. See võib olla vale, mitte sobida litsentsi nimega või olla vigane. Kontrollige üldseadeid.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,See litsentsivõti ei kehti selle tooteversiooni jaoks (vale väljalaskenumber / peaversioon). Vajate sellele kompileeringule vastavat võtit. Uuendage litsents üldseadetes.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Litsentsivõtit pole seadistatud (puudub litsentsi nimi või põhivõti). Sisestage või uuendage litsents üldseadetes.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Kehtivat litsentsifaili pole seadistatud. Kasutage .alic litsentsifaili määramiseks või juurutamiseks vahekaarti Litsentsifail üldseadetes.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Väljaanne (Versioon ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Kehtivat litsentsifaili pole seadistatud,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Litsentsifail kehtib,

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -925,6 +925,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Voulez-vous
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La clé de licence n'est pas valide pour ce produit. Elle peut être incorrecte, ne pas correspondre au nom de licence ou être corrompue. Vérifiez les paramètres généraux.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Cette clé de licence n'est pas valide pour cette version du produit (mauvaise version / release). Il faut une clé adaptée à cette build. Mettez à jour votre licence dans les paramètres généraux.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Aucune clé de licence n'est configurée (nom de licence ou clé principale manquant). Saisissez ou mettez à jour votre licence dans les paramètres généraux.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Aucun fichier de licence valide n'est configuré. Utilisez l'onglet Fichier de licence dans Paramètres généraux pour spécifier ou déployer un fichier de licence .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Aucun fichier de licence valide configuré,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Fichier de licence valide,

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -925,6 +925,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Vuoi ricari
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La chiave di licenza non è valida per questo prodotto. Potrebbe essere errata, non corrispondere al nome licenza o essere corrotta. Controllare le impostazioni generali.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Questa chiave di licenza non è valida per questa versione del prodotto (versione/release errata). È necessaria una chiave adatta a questa build. Aggiornare la licenza nelle impostazioni generali.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Nessuna chiave di licenza configurata (manca il nome licenza o la chiave principale). Immettere o aggiornare la licenza nelle impostazioni generali.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Nessun file di licenza valido configurato. Utilizzare la scheda File di licenza in Impostazioni generali per specificare o distribuire un file di licenza .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Nessun file di licenza valido configurato,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,File di licenza valido,

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -921,6 +921,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,リロー�
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,ライセンスキーはこの製品では無効です。誤入力、ライセンス名との不一致、またはデータ破損の可能性があります。一般設定を確認してください。,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,このライセンスキーはこの製品バージョンでは無効です（リリース／メジャーバージョンが一致しません）。このビルドに対応したキーが必要です。一般設定でライセンスを更新してください。,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,ライセンスキーが設定されていません（ライセンス名または主キーがありません）。一般設定でライセンスを入力または更新してください。,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,有効なライセンスファイルが設定されていません。一般設定の「ライセンスファイル」タブで .alic ライセンスファイルを指定または配置してください。,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,有効なライセンスファイルが設定されていません,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,ライセンスファイルは有効,

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -924,6 +924,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Quer recarr
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"A chave de licença não é válida para este produto. Ela pode estar incorreta, não corresponder ao nome da licença ou estar corrompida. Verifique as configurações gerais.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Esta chave de licença não é válida para esta versão do produto (versão/release incorreta). É necessária uma chave compatível com esta compilação. Atualize a licença em Configurações gerais.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Nenhuma chave de licença configurada (falta o nome da licença ou a chave principal). Informe ou atualize a licença em Configurações gerais.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Nenhum arquivo de licença válido está configurado. Use a guia Arquivo de licença em Configurações gerais para especificar ou implantar um arquivo de licença .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Nenhum arquivo de licença válido configurado,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Arquivo de licença válido,


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: 9426d053cc562291715478e7128b42231128ffce
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new banner message `szLicenseBannerNoLicenseFile` to inform users when no valid `.alic` license file is configured. Updates translations in `clientcore` CSVs for en-US, de-DE, es-ES, et-EE, fr-FR, it-IT, ja-JP, and pt-BR.

- **New Features**
  - Added `szLicenseBannerNoLicenseFile` in `language-files/clientcore/*.csv` (Main Template form).
  - Message guides users to General > License File to specify or deploy an `.alic` file.

<sup>Written for commit a1dc6c7311b67d9c7c132c6a8d5bba6c7ef196a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

