### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -925,8 +925,10 @@ ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edi
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Keine gültige Lizenzdatei konfiguriert,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Lizenzdatei gültig,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Kostenlose Version (Maximal %1 Sender),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialDaysRemaining,%1 Tage übrig,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,"Testphase ist abgelaufen, oder falsche Lizens!",
-ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Testphase, Tage übrig ",
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,Testphase,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriodOnly,Testphase,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseValidFor,Lizenz gültig für ,
 ClientCore/frmMainTemplate,Main Template Form,szLoadConfigData,Lädt Konfigurationsdaten,
 ClientCore/frmMainTemplate,Main Template Form,szLoadedRuleSet,Regelsatz geladen: ,

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -929,8 +929,10 @@ ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edi
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,No valid license file configured,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,License file valid,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Free Edition (Max %1 senders),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialDaysRemaining,%1 days remaining,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,Trial period expired or invalid license(wrong version?)!,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Trial period, days left ",
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,Trial Period,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriodOnly,Trial Period,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseValidFor,Licensed to ,
 ClientCore/frmMainTemplate,Main Template Form,szLoadConfigData,Loading configuration data,
 ClientCore/frmMainTemplate,Main Template Form,szLoadedRuleSet,Loaded RuleSet: ,

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -929,8 +929,10 @@ ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edi
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,No hay un archivo de licencia válido configurado,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Archivo de licencia válido,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Edición gratuita (máx. %1 remitentes),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialDaysRemaining,Quedan %1 días,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,¡Período de prueba expirado o licencia no válida (¿versión incorrecta?)!,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Período de prueba, días restantes ",
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,Período de prueba,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriodOnly,Período de prueba,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseValidFor,Licencia para ,
 ClientCore/frmMainTemplate,Main Template Form,szLoadConfigData,Cargando datos de configuración,
 ClientCore/frmMainTemplate,Main Template Form,szLoadedRuleSet,Conjunto de reglas cargado: ,

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -929,8 +929,10 @@ ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Vä
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Kehtivat litsentsifaili pole seadistatud,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Litsentsifail kehtib,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Tasuta väljaanne (maksimaalselt %1 saatjat),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialDaysRemaining,%1 päeva jäänud,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,Prooviperiood on aegunud või kehtetu litsents (vale versioon?)!,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Prooviperiood, päevad jäänud",
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,Prooviperiood,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriodOnly,Prooviperiood,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseValidFor,Litsentsitud,
 ClientCore/frmMainTemplate,Main Template Form,szLoadConfigData,Konfiguratsiooniandmete laadimine,
 ClientCore/frmMainTemplate,Main Template Form,szLoadedRuleSet,Laaditud reeglistik:,

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -929,8 +929,10 @@ ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edi
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Aucun fichier de licence valide configuré,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Fichier de licence valide,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Édition gratuite (maximum de %1 expéditeurs),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialDaysRemaining,%1 jours restants,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,Période d'essai expirée ou licence invalide (mauvaise version ?) !,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Période d'essai, jours restants",
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,Période d'essai,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriodOnly,Période d'essai,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseValidFor,Autorisé à,
 ClientCore/frmMainTemplate,Main Template Form,szLoadConfigData,Chargement des données de configuration,
 ClientCore/frmMainTemplate,Main Template Form,szLoadedRuleSet,RuleSet chargé :,

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -929,8 +929,10 @@ ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edi
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Nessun file di licenza valido configurato,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,File di licenza valido,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Edizione gratuita (massimo %1 mittenti),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialDaysRemaining,%1 giorni rimanenti,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,Periodo di prova scaduto o licenza non valida (versione sbagliata?)!,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Periodo di prova, giorni rimasti",
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,Periodo di prova,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriodOnly,Periodo di prova,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseValidFor,Concesso in licenza a,
 ClientCore/frmMainTemplate,Main Template Form,szLoadConfigData,Caricamento dei dati di configurazione,
 ClientCore/frmMainTemplate,Main Template Form,szLoadedRuleSet,Set di regole caricato:,

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -925,8 +925,10 @@ ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edi
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,有効なライセンスファイルが設定されていません,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,ライセンスファイルは有効,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,フリーエディション (最大送信デバイス数：%1),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialDaysRemaining,残り%1日,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,試用期間は終了しました！,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,試用期間中/残り日数：,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,試用期間,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriodOnly,試用期間,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseValidFor,ライセンスは有効です：,
 ClientCore/frmMainTemplate,Main Template Form,szLoadConfigData,設定データを読み込んでいます,
 ClientCore/frmMainTemplate,Main Template Form,szLoadedRuleSet,ルールセットの読み込み: ,

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -928,8 +928,10 @@ ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edi
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Nenhum arquivo de licença válido configurado,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Arquivo de licença válido,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFreeEdition,Edição gratuita (máximo de %1 remetentes),PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialDaysRemaining,%1 dias restantes,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialExpired,Período de teste expirou ou licença inválida (versão errada?)!,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,"Período de teste, dias restantes",
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriod,Período de avaliação,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseTrialPeriodOnly,Período de avaliação,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseValidFor,Licenciado para,
 ClientCore/frmMainTemplate,Main Template Form,szLoadConfigData,Carregando dados de configuração,
 ClientCore/frmMainTemplate,Main Template Form,szLoadedRuleSet,Conjunto de regras carregado:,


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: c79c6d759cb82929fc07c9c7da77869ed396d3f7
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Adiscon Client language CSVs to improve trial license messaging across en-US, de-DE, es-ES, et-EE, fr-FR, it-IT, ja-JP, and pt-BR. Adds szLicenseTrialDaysRemaining, introduces szLicenseTrialPeriodOnly, and simplifies szLicenseTrialPeriod; CSV keys/structure unchanged and %1 placeholders preserved.

<sup>Written for commit d6a77e98a8c9460aa2f2b312676ff076fffc7bf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

