### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -921,6 +921,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,"Der Konfig
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Wollen Sie jetzt neuladen?,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"Der Lizenzschlüssel ist für dieses Produkt ungültig. Er kann falsch eingegeben sein, nicht zum Lizenznamen passen oder beschädigt sein. Prüfen Sie die Einstellungen unter Allgemein.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,"Dieser Lizenzschlüssel ist für diese Produktversion ungültig (falsche Release- bzw. Hauptversion). Sie benötigen einen Schlüssel, der zu diesem Build passt. Aktualisieren Sie die Lizenz unter Allgemein.",
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"Diese Lizenzdatei gilt für Hauptversion %LICENSEMAJORS%, der installierte Dienst meldet jedoch Hauptversion %SERVICEMAJOR%. Starten Sie den Dienst nach einem Update neu, damit die Lizenzierung übereinstimmt.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Es ist kein Lizenzschlüssel hinterlegt (Lizenzname oder Hauptschlüssel fehlt). Geben Sie Ihre Lizenz unter Allgemein ein oder aktualisieren Sie sie.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,"Es ist keine gültige Lizenzdatei konfiguriert. Verwenden Sie die Registerkarte „Lizenzdatei“ unter Allgemein, um eine .alic-Lizenzdatei anzugeben oder bereitzustellen.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
@@ -1812,6 +1813,15 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTi
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,.alic-Datei hier ablegen oder per Rechtsklick »Pfad einfügen« nach Explorer »Als Pfad kopieren« (wenn Drag-and-Drop blockiert ist).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Nur .alic-Lizenzdateien können hier abgelegt werden.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Lizenzdatei,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,"Warnung: Diese Lizenz gilt für Hauptversion %LICENSEMAJORS%. Der installierte Dienst meldet Hauptversion %SERVICEMAJOR%. Starten Sie den Dienst nach einem Update neu, damit die Lizenzierung übereinstimmt.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"Diese Lizenzdatei gilt für Hauptversion %LICENSEMAJORS%, der installierte Dienst meldet jedoch Hauptversion %SERVICEMAJOR%.
+
+%DETAIL%
+
+Lizenzdatei trotzdem installieren?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Wenn Sie den Dienst gerade aktualisiert haben, starten Sie ihn neu, damit die installierte Version zur Lizenz passt.",
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"Diese Lizenzdatei gilt für Hauptversion %LICENSEMAJORS%, der installierte Dienst meldet jedoch Hauptversion %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Diesen Lizenzdateipfad trotzdem speichern?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Vorhandene license.alic am Standardspeicherort überschreiben?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Der eingefügte Pfad zur Lizenzdatei existiert nicht.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Die Zwischenablage enthält keinen gültigen Pfad zur Lizenzdatei.,

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -925,6 +925,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,A reload of
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Do you want to reload now?,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"The license key is not valid for this product. It may be mistyped, not match the license name, or be corrupted. Check General settings.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,This license key is not valid for this version of the product (wrong release / major version). You need a key that matches this build. Update your license in General settings.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"This license file is for major version %LICENSEMAJORS%, but the installed service reports major version %SERVICEMAJOR%. Restart the service after an update so licensing matches.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,No license key is configured (license name or primary key is missing). Enter or update your license in General settings.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,No valid license file is configured. Use the License File tab under General settings to specify or deploy a .alic license file.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
@@ -1817,6 +1818,15 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTi
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,"Drop a .alic file here, or right-click and choose Paste path after using Explorer Copy as path (useful when drag-and-drop is blocked).",
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Only .alic license files can be dropped here.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,License File,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,Warning: This license is for major version %LICENSEMAJORS%. The installed service reports major version %SERVICEMAJOR%. Restart the service after an update so licensing matches.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"This license file is for major version %LICENSEMAJORS%, but the installed service reports major version %SERVICEMAJOR%.
+
+%DETAIL%
+
+Install this license file anyway?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"If you just updated the service, restart it so the installed version matches the license.",
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"This license file is for major version %LICENSEMAJORS%, but the installed service reports major version %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Save this license file path anyway?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Overwrite the existing license.alic at the default location?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,The pasted license file path does not exist.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,The clipboard does not contain a valid license file path.,

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -925,6 +925,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Es necesari
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,¿Desea reiniciar ahora?,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La clave de licencia no es válida para este producto. Puede estar mal escrita, no coincidir con el nombre de licencia o estar corrupta. Revise la configuración general.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Esta clave de licencia no es válida para esta versión del producto (versión o release incorrecta). Necesita una clave que corresponda a esta compilación. Actualice la licencia en la configuración general.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"Este archivo de licencia es para la versión principal %LICENSEMAJORS%, pero el servicio instalado informa la versión principal %SERVICEMAJOR%. Reinicie el servicio después de una actualización para que la licencia coincida.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,No hay clave de licencia configurada (falta el nombre de licencia o la clave principal). Introduzca o actualice su licencia en la configuración general.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,No hay ningún archivo de licencia válido configurado. Use la pestaña Archivo de licencia en Configuración general para especificar o implementar un archivo de licencia .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
@@ -1811,6 +1812,15 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTi
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Suelte un archivo .alic aquí o haga clic derecho y elija Pegar ruta tras Copiar como ruta en el Explorador (si el arrastrar y soltar está bloqueado).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Solo se pueden soltar aquí archivos de licencia .alic.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Archivo de licencia,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,Advertencia: Esta licencia es para la versión principal %LICENSEMAJORS%. El servicio instalado informa la versión principal %SERVICEMAJOR%. Reinicie el servicio después de una actualización para que la licencia coincida.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"Este archivo de licencia es para la versión principal %LICENSEMAJORS%, pero el servicio instalado informa la versión principal %SERVICEMAJOR%.
+
+%DETAIL%
+
+¿Instalar este archivo de licencia de todos modos?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Si acaba de actualizar el servicio, reinícielo para que la versión instalada coincida con la licencia.",
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"Este archivo de licencia es para la versión principal %LICENSEMAJORS%, pero el servicio instalado informa la versión principal %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,¿Guardar esta ruta del archivo de licencia de todos modos?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,¿Sobrescribir el license.alic existente en la ubicación predeterminada?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,La ruta de archivo de licencia pegada no existe.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,El portapapeles no contiene una ruta de archivo de licencia válida.,

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -925,6 +925,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Muudatuste 
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Kas soovite nüüd uuesti laadida?,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"Litsentsivõti ei kehti selle toote jaoks. See võib olla vale, mitte sobida litsentsi nimega või olla vigane. Kontrollige üldseadeid.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,See litsentsivõti ei kehti selle tooteversiooni jaoks (vale väljalaskenumber / peaversioon). Vajate sellele kompileeringule vastavat võtit. Uuendage litsents üldseadetes.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"See litsentsifail on peaversioonile %LICENSEMAJORS%, kuid installitud teenus teatab peaversiooni %SERVICEMAJOR%. Taaskäivitage teenus pärast uuendust, et litsents vastaks.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Litsentsivõtit pole seadistatud (puudub litsentsi nimi või põhivõti). Sisestage või uuendage litsents üldseadetes.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Kehtivat litsentsifaili pole seadistatud. Kasutage .alic litsentsifaili määramiseks või juurutamiseks vahekaarti Litsentsifail üldseadetes.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Väljaanne (Versioon ,
@@ -1817,6 +1818,15 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTi
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Lohistage .alic fail siia või tehke paremklõps ja valige Kleebi tee pärast Exploreris Kopeeri tee (kui lohistamine on blokeeritud).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Siia saab lohistada ainult .alic litsentsifaile.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Litsentsifail,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,"Hoiatus: see litsents kehtib peaversioonile %LICENSEMAJORS%. Installitud teenus teatab peaversiooni %SERVICEMAJOR%. Taaskäivitage teenus pärast uuendust, et litsents vastaks.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"See litsentsifail on peaversioonile %LICENSEMAJORS%, kuid installitud teenus teatab peaversiooni %SERVICEMAJOR%.
+
+%DETAIL%
+
+Kas installida see litsentsifail ikkagi?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Kui uuendasite teenust just äsja, taaskäivitage see, et installitud versioon vastaks litsentsile.",
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"See litsentsifail on peaversioonile %LICENSEMAJORS%, kuid installitud teenus teatab peaversiooni %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Kas salvestada see litsentsifaili tee ikkagi?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Kas kirjutada vaikimisi asukohas olemasolev license.alic üle?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Kleebitud litsentsifaili teed ei eksisteeri.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Lõikelaual pole kehtivat litsentsifaili teed.,

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -925,6 +925,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Un recharge
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Voulez-vous recharger maintenant ?,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La clé de licence n'est pas valide pour ce produit. Elle peut être incorrecte, ne pas correspondre au nom de licence ou être corrompue. Vérifiez les paramètres généraux.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Cette clé de licence n'est pas valide pour cette version du produit (mauvaise version / release). Il faut une clé adaptée à cette build. Mettez à jour votre licence dans les paramètres généraux.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"Ce fichier de licence est pour la version majeure %LICENSEMAJORS%, mais le service installé signale la version majeure %SERVICEMAJOR%. Redémarrez le service après une mise à jour pour que la licence corresponde.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Aucune clé de licence n'est configurée (nom de licence ou clé principale manquant). Saisissez ou mettez à jour votre licence dans les paramètres généraux.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Aucun fichier de licence valide n'est configuré. Utilisez l'onglet Fichier de licence dans Paramètres généraux pour spécifier ou déployer un fichier de licence .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
@@ -1817,6 +1818,15 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTi
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Déposez un fichier .alic ici ou cliquez droit et choisissez Coller le chemin après Copier comme chemin dans l'Explorateur (si le glisser-déposer est bloqué).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Seuls les fichiers de licence .alic peuvent être déposés ici.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Fichier de licence,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,Avertissement : Cette licence est pour la version majeure %LICENSEMAJORS%. Le service installé signale la version majeure %SERVICEMAJOR%. Redémarrez le service après une mise à jour pour que la licence corresponde.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"Ce fichier de licence est pour la version majeure %LICENSEMAJORS%, mais le service installé signale la version majeure %SERVICEMAJOR%.
+
+%DETAIL%
+
+Installer ce fichier de licence quand même ?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Si vous venez de mettre à jour le service, redémarrez-le pour que la version installée corresponde à la licence.",
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"Ce fichier de licence est pour la version majeure %LICENSEMAJORS%, mais le service installé signale la version majeure %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Enregistrer ce chemin de fichier de licence quand même ?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Remplacer le license.alic existant à l'emplacement par défaut ?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Le chemin de fichier de licence collé n'existe pas.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Le presse-papiers ne contient pas de chemin de fichier de licence valide.,

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -925,6 +925,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Per complet
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Vuoi ricaricare adesso?,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La chiave di licenza non è valida per questo prodotto. Potrebbe essere errata, non corrispondere al nome licenza o essere corrotta. Controllare le impostazioni generali.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Questa chiave di licenza non è valida per questa versione del prodotto (versione/release errata). È necessaria una chiave adatta a questa build. Aggiornare la licenza nelle impostazioni generali.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"Questo file di licenza è per la versione principale %LICENSEMAJORS%, ma il servizio installato riporta la versione principale %SERVICEMAJOR%. Riavviare il servizio dopo un aggiornamento affinché la licenza corrisponda.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Nessuna chiave di licenza configurata (manca il nome licenza o la chiave principale). Immettere o aggiornare la licenza nelle impostazioni generali.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Nessun file di licenza valido configurato. Utilizzare la scheda File di licenza in Impostazioni generali per specificare o distribuire un file di licenza .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
@@ -1817,6 +1818,15 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTi
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Trascinare qui un file .alic o fare clic destro e scegliere Incolla percorso dopo Copia percorso in Esplora file (se il trascinamento è bloccato).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Solo file di licenza .alic possono essere rilasciati qui.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,File di licenza,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,Avviso: Questa licenza è per la versione principale %LICENSEMAJORS%. Il servizio installato riporta la versione principale %SERVICEMAJOR%. Riavviare il servizio dopo un aggiornamento affinché la licenza corrisponda.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"Questo file di licenza è per la versione principale %LICENSEMAJORS%, ma il servizio installato riporta la versione principale %SERVICEMAJOR%.
+
+%DETAIL%
+
+Installare comunque questo file di licenza?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Se avete appena aggiornato il servizio, riavviatelo affinché la versione installata corrisponda alla licenza.",
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"Questo file di licenza è per la versione principale %LICENSEMAJORS%, ma il servizio installato riporta la versione principale %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Salvare comunque questo percorso del file di licenza?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Sovrascrivere il license.alic esistente nella posizione predefinita?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Il percorso del file di licenza incollato non esiste.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Gli appunti non contengono un percorso di file di licenza valido.,

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -921,6 +921,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,変更す�
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,リロードしますか？,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,ライセンスキーはこの製品では無効です。誤入力、ライセンス名との不一致、またはデータ破損の可能性があります。一般設定を確認してください。,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,このライセンスキーはこの製品バージョンでは無効です（リリース／メジャーバージョンが一致しません）。このビルドに対応したキーが必要です。一般設定でライセンスを更新してください。,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,このライセンスファイルはメジャーバージョン %LICENSEMAJORS% 用ですが、インストール済みサービスはメジャーバージョン %SERVICEMAJOR% を報告しています。更新後はサービスを再起動してライセンスを一致させてください。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,ライセンスキーが設定されていません（ライセンス名または主キーがありません）。一般設定でライセンスを入力または更新してください。,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,有効なライセンスファイルが設定されていません。一般設定の「ライセンスファイル」タブで .alic ライセンスファイルを指定または配置してください。,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
@@ -1822,6 +1823,15 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTi
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,.alic ファイルをここにドロップするか、エクスプローラーで「パスのコピー」の後に右クリックして「パスを貼り付け」を選択してください（ドラッグアンドドロップがブロックされている場合）。,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,ここにドロップできるのは .alic ライセンスファイルのみです。,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,ライセンスファイル,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,警告: このライセンスはメジャーバージョン %LICENSEMAJORS% 用です。インストール済みサービスはメジャーバージョン %SERVICEMAJOR% を報告しています。更新後はサービスを再起動してライセンスを一致させてください。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"このライセンスファイルはメジャーバージョン %LICENSEMAJORS% 用ですが、インストール済みサービスはメジャーバージョン %SERVICEMAJOR% を報告しています。
+
+%DETAIL%
+
+このライセンスファイルをインストールしますか？",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,サービスを更新した直後の場合は、ライセンスと一致するようサービスを再起動してください。,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,このライセンスファイルはメジャーバージョン %LICENSEMAJORS% 用ですが、インストール済みサービスはメジャーバージョン %SERVICEMAJOR% を報告しています。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,このライセンスファイルのパスを保存しますか？,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,既定の場所にある既存の license.alic を上書きしますか？,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,貼り付けたライセンスファイルのパスが存在しません。,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,クリップボードに有効なライセンスファイルのパスが含まれていません。,

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -924,6 +924,7 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,É necessá
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Quer recarregar agora?,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"A chave de licença não é válida para este produto. Ela pode estar incorreta, não corresponder ao nome da licença ou estar corrompida. Verifique as configurações gerais.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Esta chave de licença não é válida para esta versão do produto (versão/release incorreta). É necessária uma chave compatível com esta compilação. Atualize a licença em Configurações gerais.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"Este arquivo de licença é para a versão principal %LICENSEMAJORS%, mas o serviço instalado informa a versão principal %SERVICEMAJOR%. Reinicie o serviço após uma atualização para que a licença corresponda.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Nenhuma chave de licença configurada (falta o nome da licença ou a chave principal). Informe ou atualize a licença em Configurações gerais.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Nenhum arquivo de licença válido está configurado. Use a guia Arquivo de licença em Configurações gerais para especificar ou implantar um arquivo de licença .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
@@ -1816,6 +1817,15 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTi
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Solte um arquivo .alic aqui ou clique com o botão direito e escolha Colar caminho após Copiar como caminho no Explorer (quando arrastar e soltar estiver bloqueado).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Somente arquivos de licença .alic podem ser soltos aqui.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Arquivo de licença,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,Aviso: Esta licença é para a versão principal %LICENSEMAJORS%. O serviço instalado informa a versão principal %SERVICEMAJOR%. Reinicie o serviço após uma atualização para que a licença corresponda.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"Este arquivo de licença é para a versão principal %LICENSEMAJORS%, mas o serviço instalado informa a versão principal %SERVICEMAJOR%.
+
+%DETAIL%
+
+Instalar este arquivo de licença mesmo assim?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Se você acabou de atualizar o serviço, reinicie-o para que a versão instalada corresponda à licença.",
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"Este arquivo de licença é para a versão principal %LICENSEMAJORS%, mas o serviço instalado informa a versão principal %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Salvar este caminho do arquivo de licença mesmo assim?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Substituir o license.alic existente no local padrão?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,O caminho do arquivo de licença colado não existe.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,A área de transferência não contém um caminho de arquivo de licença válido.,


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: f1d8862ca22b81901790d54265c07a842c8fcbf6
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new license V2 major-version mismatch messages to the client core language CSVs. Improves guidance when a license file’s major version differs from the installed service.

- **New Features**
  - Added banner and dialogs: mismatch warning, accepted info, confirm (with %DETAIL%), summary, and save-path confirm; placeholders `%LICENSEMAJORS%`, `%SERVICEMAJOR%`, `%DETAIL%` preserved.
  - Localized in `en-US`, `de-DE`, `es-ES`, `et-EE`, `fr-FR`, `it-IT`, `ja-JP`, `pt-BR`.
  - Keys/structure unchanged; updates are text additions only per CSV comments policy.

<sup>Written for commit 4247d9c1cae2afe851c69767a7800de9d69dff75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

