### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -1812,6 +1812,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultP
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Lizenzdatei,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,.alic-Datei hier ablegen oder per Rechtsklick »Pfad einfügen« nach Explorer »Als Pfad kopieren« (wenn Drag-and-Drop blockiert ist).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Nur .alic-Lizenzdateien können hier abgelegt werden.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Expired,Die Lizenzdatei ist abgelaufen.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Lizenzdatei,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,"Warnung: Diese Lizenz gilt für Hauptversion %LICENSEMAJORS%. Der installierte Dienst meldet Hauptversion %SERVICEMAJOR%. Starten Sie den Dienst nach einem Update neu, damit die Lizenzierung übereinstimmt.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"Diese Lizenzdatei gilt für Hauptversion %LICENSEMAJORS%, der installierte Dienst meldet jedoch Hauptversion %SERVICEMAJOR%.
@@ -1822,6 +1823,9 @@ Lizenzdatei trotzdem installieren?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exa
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Wenn Sie den Dienst gerade aktualisiert haben, starten Sie ihn neu, damit die installierte Version zur Lizenz passt.",
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"Diese Lizenzdatei gilt für Hauptversion %LICENSEMAJORS%, der installierte Dienst meldet jedoch Hauptversion %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Diesen Lizenzdateipfad trotzdem speichern?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValid,Diese Lizenzdatei ist noch nicht aktiv. Sie wird gültig am %VALIDFROMLOCAL% (UTC: %VALIDFROMUTC%). Bitte versuchen Sie es nach diesem Zeitpunkt erneut.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidGeneric,Die Lizenzdatei ist noch nicht gültig.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidIssued,Die Lizenz wurde ausgestellt am %ISSUEDATLOCAL%.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Vorhandene license.alic am Standardspeicherort überschreiben?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Der eingefügte Pfad zur Lizenzdatei existiert nicht.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Die Zwischenablage enthält keinen gültigen Pfad zur Lizenzdatei.,

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -1817,6 +1817,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultP
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,License File,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,"Drop a .alic file here, or right-click and choose Paste path after using Explorer Copy as path (useful when drag-and-drop is blocked).",
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Only .alic license files can be dropped here.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Expired,The license file has expired.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,License File,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,Warning: This license is for major version %LICENSEMAJORS%. The installed service reports major version %SERVICEMAJOR%. Restart the service after an update so licensing matches.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"This license file is for major version %LICENSEMAJORS%, but the installed service reports major version %SERVICEMAJOR%.
@@ -1827,6 +1828,9 @@ Install this license file anyway?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exac
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"If you just updated the service, restart it so the installed version matches the license.",
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"This license file is for major version %LICENSEMAJORS%, but the installed service reports major version %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Save this license file path anyway?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValid,This license file is not active yet. It becomes valid on %VALIDFROMLOCAL% (UTC: %VALIDFROMUTC%). Please try again after that time.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidGeneric,The license file is not yet valid.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidIssued,The license was issued on %ISSUEDATLOCAL%.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Overwrite the existing license.alic at the default location?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,The pasted license file path does not exist.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,The clipboard does not contain a valid license file path.,

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -1811,6 +1811,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultP
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Archivo de licencia,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Suelte un archivo .alic aquí o haga clic derecho y elija Pegar ruta tras Copiar como ruta en el Explorador (si el arrastrar y soltar está bloqueado).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Solo se pueden soltar aquí archivos de licencia .alic.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Expired,El archivo de licencia ha caducado.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Archivo de licencia,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,Advertencia: Esta licencia es para la versión principal %LICENSEMAJORS%. El servicio instalado informa la versión principal %SERVICEMAJOR%. Reinicie el servicio después de una actualización para que la licencia coincida.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"Este archivo de licencia es para la versión principal %LICENSEMAJORS%, pero el servicio instalado informa la versión principal %SERVICEMAJOR%.
@@ -1821,6 +1822,9 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVer
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Si acaba de actualizar el servicio, reinícielo para que la versión instalada coincida con la licencia.",
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"Este archivo de licencia es para la versión principal %LICENSEMAJORS%, pero el servicio instalado informa la versión principal %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,¿Guardar esta ruta del archivo de licencia de todos modos?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValid,Este archivo de licencia aún no está activo. Será válido el %VALIDFROMLOCAL% (UTC: %VALIDFROMUTC%). Vuelva a intentarlo después de esa hora.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidGeneric,El archivo de licencia aún no es válido.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidIssued,La licencia se emitió el %ISSUEDATLOCAL%.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,¿Sobrescribir el license.alic existente en la ubicación predeterminada?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,La ruta de archivo de licencia pegada no existe.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,El portapapeles no contiene una ruta de archivo de licencia válida.,

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -1817,6 +1817,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultP
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Litsentsifail,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Lohistage .alic fail siia või tehke paremklõps ja valige Kleebi tee pärast Exploreris Kopeeri tee (kui lohistamine on blokeeritud).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Siia saab lohistada ainult .alic litsentsifaile.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Expired,Litsentsifail on aegunud.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Litsentsifail,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,"Hoiatus: see litsents kehtib peaversioonile %LICENSEMAJORS%. Installitud teenus teatab peaversiooni %SERVICEMAJOR%. Taaskäivitage teenus pärast uuendust, et litsents vastaks.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"See litsentsifail on peaversioonile %LICENSEMAJORS%, kuid installitud teenus teatab peaversiooni %SERVICEMAJOR%.
@@ -1827,6 +1828,9 @@ Kas installida see litsentsifail ikkagi?",PLACEHOLDER_REQUIRED: preserve %1/%2/e
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Kui uuendasite teenust just äsja, taaskäivitage see, et installitud versioon vastaks litsentsile.",
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"See litsentsifail on peaversioonile %LICENSEMAJORS%, kuid installitud teenus teatab peaversiooni %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Kas salvestada see litsentsifaili tee ikkagi?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValid,See litsentsifail pole veel aktiivne. See muutub kehtivaks %VALIDFROMLOCAL% (UTC: %VALIDFROMUTC%). Proovige pärast seda aega uuesti.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidGeneric,Litsentsifail pole veel kehtiv.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidIssued,Litsents väljastati %ISSUEDATLOCAL%.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Kas kirjutada vaikimisi asukohas olemasolev license.alic üle?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Kleebitud litsentsifaili teed ei eksisteeri.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Lõikelaual pole kehtivat litsentsifaili teed.,

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -1817,6 +1817,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultP
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Fichier de licence,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Déposez un fichier .alic ici ou cliquez droit et choisissez Coller le chemin après Copier comme chemin dans l'Explorateur (si le glisser-déposer est bloqué).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Seuls les fichiers de licence .alic peuvent être déposés ici.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Expired,Le fichier de licence a expiré.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Fichier de licence,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,Avertissement : Cette licence est pour la version majeure %LICENSEMAJORS%. Le service installé signale la version majeure %SERVICEMAJOR%. Redémarrez le service après une mise à jour pour que la licence corresponde.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"Ce fichier de licence est pour la version majeure %LICENSEMAJORS%, mais le service installé signale la version majeure %SERVICEMAJOR%.
@@ -1827,6 +1828,9 @@ Installer ce fichier de licence quand même ?",PLACEHOLDER_REQUIRED: preserve %1
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Si vous venez de mettre à jour le service, redémarrez-le pour que la version installée corresponde à la licence.",
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"Ce fichier de licence est pour la version majeure %LICENSEMAJORS%, mais le service installé signale la version majeure %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Enregistrer ce chemin de fichier de licence quand même ?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValid,Ce fichier de licence n'est pas encore actif. Il sera valide le %VALIDFROMLOCAL% (UTC : %VALIDFROMUTC%). Veuillez réessayer après cette heure.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidGeneric,Le fichier de licence n'est pas encore valide.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidIssued,La licence a été émise le %ISSUEDATLOCAL%.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Remplacer le license.alic existant à l'emplacement par défaut ?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Le chemin de fichier de licence collé n'existe pas.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Le presse-papiers ne contient pas de chemin de fichier de licence valide.,

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -1817,6 +1817,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultP
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,File di licenza,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Trascinare qui un file .alic o fare clic destro e scegliere Incolla percorso dopo Copia percorso in Esplora file (se il trascinamento è bloccato).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Solo file di licenza .alic possono essere rilasciati qui.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Expired,Il file di licenza è scaduto.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,File di licenza,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,Avviso: Questa licenza è per la versione principale %LICENSEMAJORS%. Il servizio installato riporta la versione principale %SERVICEMAJOR%. Riavviare il servizio dopo un aggiornamento affinché la licenza corrisponda.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"Questo file di licenza è per la versione principale %LICENSEMAJORS%, ma il servizio installato riporta la versione principale %SERVICEMAJOR%.
@@ -1827,6 +1828,9 @@ Installare comunque questo file di licenza?",PLACEHOLDER_REQUIRED: preserve %1/%
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Se avete appena aggiornato il servizio, riavviatelo affinché la versione installata corrisponda alla licenza.",
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"Questo file di licenza è per la versione principale %LICENSEMAJORS%, ma il servizio installato riporta la versione principale %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Salvare comunque questo percorso del file di licenza?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValid,Questo file di licenza non è ancora attivo. Diventerà valido il %VALIDFROMLOCAL% (UTC: %VALIDFROMUTC%). Riprovare dopo tale orario.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidGeneric,Il file di licenza non è ancora valido.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidIssued,La licenza è stata emessa il %ISSUEDATLOCAL%.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Sovrascrivere il license.alic esistente nella posizione predefinita?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,Il percorso del file di licenza incollato non esiste.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,Gli appunti non contengono un percorso di file di licenza valido.,

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -1822,6 +1822,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultP
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,ライセンスファイル,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,.alic ファイルをここにドロップするか、エクスプローラーで「パスのコピー」の後に右クリックして「パスを貼り付け」を選択してください（ドラッグアンドドロップがブロックされている場合）。,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,ここにドロップできるのは .alic ライセンスファイルのみです。,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Expired,ライセンスファイルの有効期限が切れています。,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,ライセンスファイル,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,警告: このライセンスはメジャーバージョン %LICENSEMAJORS% 用です。インストール済みサービスはメジャーバージョン %SERVICEMAJOR% を報告しています。更新後はサービスを再起動してライセンスを一致させてください。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"このライセンスファイルはメジャーバージョン %LICENSEMAJORS% 用ですが、インストール済みサービスはメジャーバージョン %SERVICEMAJOR% を報告しています。
@@ -1832,6 +1833,9 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVer
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,サービスを更新した直後の場合は、ライセンスと一致するようサービスを再起動してください。,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,このライセンスファイルはメジャーバージョン %LICENSEMAJORS% 用ですが、インストール済みサービスはメジャーバージョン %SERVICEMAJOR% を報告しています。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,このライセンスファイルのパスを保存しますか？,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValid,このライセンスファイルはまだ有効ではありません。%VALIDFROMLOCAL%（UTC: %VALIDFROMUTC%）から有効になります。その時刻以降に再度お試しください。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidGeneric,ライセンスファイルはまだ有効ではありません。,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidIssued,ライセンスの発行日時: %ISSUEDATLOCAL%,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,既定の場所にある既存の license.alic を上書きしますか？,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,貼り付けたライセンスファイルのパスが存在しません。,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,クリップボードに有効なライセンスファイルのパスが含まれていません。,

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -1816,6 +1816,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultP
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Arquivo de licença,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropHint,Solte um arquivo .alic aqui ou clique com o botão direito e escolha Colar caminho após Copiar como caminho no Explorer (quando arrastar e soltar estiver bloqueado).,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DropInvalidExtension,Somente arquivos de licença .alic podem ser soltos aqui.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Expired,O arquivo de licença expirou.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2InvalidTitle,Arquivo de licença,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionAcceptedInfo,Aviso: Esta licença é para a versão principal %LICENSEMAJORS%. O serviço instalado informa a versão principal %SERVICEMAJOR%. Reinicie o serviço após uma atualização para que a licença corresponda.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirm,"Este arquivo de licença é para a versão principal %LICENSEMAJORS%, mas o serviço instalado informa a versão principal %SERVICEMAJOR%.
@@ -1826,6 +1827,9 @@ Instalar este arquivo de licença mesmo assim?",PLACEHOLDER_REQUIRED: preserve %
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionConfirmDetail,"Se você acabou de atualizar o serviço, reinicie-o para que a versão instalada corresponda à licença.",
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionMismatchSummary,"Este arquivo de licença é para a versão principal %LICENSEMAJORS%, mas o serviço instalado informa a versão principal %SERVICEMAJOR%.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2MajorVersionSaveConfirm,Salvar este caminho do arquivo de licença mesmo assim?,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValid,Este arquivo de licença ainda não está ativo. Ele será válido em %VALIDFROMLOCAL% (UTC: %VALIDFROMUTC%). Tente novamente após esse horário.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidGeneric,O arquivo de licença ainda não é válido.,
+ClientCore/xml.languagefiles/General.License,License General,szLicenseV2NotYetValidIssued,A licença foi emitida em %ISSUEDATLOCAL%.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2OverwriteConfirm,Substituir o license.alic existente no local padrão?,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteFileNotFound,O caminho do arquivo de licença colado não existe.,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2PasteInvalidPath,A área de transferência não contém um caminho de arquivo de licença válido.,


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: 2d24dde2bdcd9f78286f5feb6b67d8f44564c093
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four new license status messages to the Adiscon Client language CSVs so users see clear prompts when a license file is expired or not yet valid. Updates eight locales: en-US, de-DE, es-ES, et-EE, fr-FR, it-IT, ja-JP, pt-BR.

- **New Features**
  - Added strings: szLicenseV2Expired, szLicenseV2NotYetValid, szLicenseV2NotYetValidGeneric, szLicenseV2NotYetValidIssued.
  - Preserves placeholders (%VALIDFROMLOCAL%, %VALIDFROMUTC%, %ISSUEDATLOCAL%) and keeps CSV structure unchanged.

<sup>Written for commit a01d02821cca6e326411a4acf4666587734a0602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

