### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -1803,10 +1803,10 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Key5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Lizenz verifizieren,
 ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Lizenz,
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Legacy-Lizenzschlüssel,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,Für installierte Dienste mit Hauptversion vor 2026 verwenden Sie unten den Registrierungsnamen und die Lizenzschlüssel. Für Version 2026 und höher verwenden Sie die Registerkarte Lizenzdatei.,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Für ältere installierte Dienste, die Registrierungsname und Lizenzschlüssel verwenden, tragen Sie diese unten ein. Für Version 26 und höher verwenden Sie die Registerkarte Lizenzdatei.",
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Legacy-Lizenz,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Lizenz Informationen,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,Für installierte Dienste mit Hauptversion 2026 und höher verwenden Sie eine Lizenzdatei (.alic). Der Standardspeicherort ist %DEFAULTLICENSEV2PATH%. Für ältere Dienstversionen verwenden Sie die Registerkarte Legacy-Lizenz.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,Für installierte Dienste mit Version 26 und höher verwenden Sie eine Lizenzdatei (.alic). Der Standardspeicherort ist %DEFAULTLICENSEV2PATH%. Für ältere Dienstversionen verwenden Sie die Registerkarte Legacy-Lizenz.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Lizenzdatei,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,"Standardpfad zur Laufzeit: %DEFAULTLICENSEV2PATH%. Feld leer lassen, um diesen Speicherort zu verwenden.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Lizenzdatei,

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -1808,10 +1808,10 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Key5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verify License,
 ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,License,
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Legacy license keys,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"For installed services with major version before 2026, use the registration name and license keys below. For version 2026 and later, use the License File tab.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"For older installed services that use registration name and license keys, enter them below. For version 26 and later, use the License File tab.",
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Legacy License,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,License Information,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"For installed services with major version 2026 and later, use a license file (.alic). The default location is %DEFAULTLICENSEV2PATH%. For older service versions, use the Legacy License tab.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"For installed services with version 26 and later, use a license file (.alic). The default location is %DEFAULTLICENSEV2PATH%. For older service versions, use the Legacy License tab.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,License File,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Default runtime path: %DEFAULTLICENSEV2PATH%. Leave this field empty to use that location.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,License File,

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -1802,10 +1802,10 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Clave5
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verificar licencia,
 ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licencia,
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Claves de licencia heredadas,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Para servicios instalados con versión principal anterior a 2026, use el nombre de registro y las claves de licencia siguientes. Para la versión 2026 y posteriores, use la pestaña Archivo de licencia.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Para servicios instalados más antiguos que usan nombre de registro y claves de licencia, introdúzcalos a continuación. Para la versión 26 y posteriores, use la pestaña Archivo de licencia.",
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licencia heredada,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Información de licencia,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Para servicios instalados con versión principal 2026 o posterior, use un archivo de licencia (.alic). La ubicación predeterminada es %DEFAULTLICENSEV2PATH%. Para versiones de servicio anteriores, use la pestaña Licencia heredada.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Para servicios instalados con versión 26 y posteriores, use un archivo de licencia (.alic). La ubicación predeterminada es %DEFAULTLICENSEV2PATH%. Para versiones de servicio anteriores, use la pestaña Licencia heredada.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Archivo de licencia,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Ruta predeterminada en tiempo de ejecución: %DEFAULTLICENSEV2PATH%. Deje este campo vacío para usar esa ubicación.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Archivo de licencia,

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -1808,10 +1808,10 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Võti 
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Kinnitage litsents,
 ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Litsents,
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Pärandlitsentsi võtmed,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Installitud teenuste puhul, mille peamine versioon on enne 2026, kasutage allpool registreerimisnime ja litsentsivõtmeid. Versiooni 2026 ja uuemate puhul kasutage vahekaarti Litsentsifail.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Vanemate installitud teenuste puhul, mis kasutavad registreerimisnime ja litsentsivõtmeid, sisestage need allpool. Versiooni 26 ja uuemate puhul kasutage vahekaarti Litsentsifail.",
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Pärandlitsents,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Litsentsi teave,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Installitud teenuste puhul, mille peamine versioon on 2026 või uuem, kasutage litsentsifaili (.alic). Vaikimisi asukoht on %DEFAULTLICENSEV2PATH%. Vanemate teenuseversioonide puhul kasutage vahekaarti Pärandlitsents.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,Installitud teenuste puhul versiooniga 26 või uuem kasutage litsentsifaili (.alic). Vaikimisi asukoht on %DEFAULTLICENSEV2PATH%. Vanemate teenuseversioonide puhul kasutage vahekaarti Pärandlitsents.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Litsentsifail,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,"Vaikimisi käivitusteekond: %DEFAULTLICENSEV2PATH%. Jätke väli tühjaks, et kasutada seda asukohta.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Litsentsifail,

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -1808,10 +1808,10 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Clé5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Vérifier la licence,
 ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licence,
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Clés de licence héritées,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Pour les services installés en version majeure antérieure à 2026, utilisez le nom d'enregistrement et les clés de licence ci-dessous. Pour la version 2026 et ultérieure, utilisez l'onglet Fichier de licence.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Pour les services installés plus anciens qui utilisent un nom d'enregistrement et des clés de licence, saisissez-les ci-dessous. Pour la version 26 et ultérieure, utilisez l'onglet Fichier de licence.",
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licence héritée,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Informations sur la licence,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Pour les services installés en version majeure 2026 ou ultérieure, utilisez un fichier de licence (.alic). L'emplacement par défaut est %DEFAULTLICENSEV2PATH%. Pour les versions de service plus anciennes, utilisez l'onglet Licence héritée.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Pour les services installés en version 26 ou ultérieure, utilisez un fichier de licence (.alic). L'emplacement par défaut est %DEFAULTLICENSEV2PATH%. Pour les versions de service plus anciennes, utilisez l'onglet Licence héritée.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Fichier de licence,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Chemin d'exécution par défaut : %DEFAULTLICENSEV2PATH%. Laissez ce champ vide pour utiliser cet emplacement.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Fichier de licence,

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -1808,10 +1808,10 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Chiave
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verifica licenza,
 ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licenza,
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Chiavi di licenza legacy,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Per i servizi installati con versione principale precedente al 2026, usare il nome di registrazione e le chiavi di licenza sotto. Per la versione 2026 e successive, usare la scheda File di licenza.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Per i servizi installati più vecchi che usano nome di registrazione e chiavi di licenza, inserirli sotto. Per la versione 26 e successive, usare la scheda File di licenza.",
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licenza legacy,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Informazioni sulla licenza,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Per i servizi installati con versione principale 2026 o successiva, usare un file di licenza (.alic). La posizione predefinita è %DEFAULTLICENSEV2PATH%. Per versioni di servizio precedenti, usare la scheda Licenza legacy.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Per i servizi installati con versione 26 o successiva, usare un file di licenza (.alic). La posizione predefinita è %DEFAULTLICENSEV2PATH%. Per versioni di servizio precedenti, usare la scheda Licenza legacy.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,File di licenza,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Percorso predefinito in runtime: %DEFAULTLICENSEV2PATH%. Lasciare vuoto per usare tale percorso.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,File di licenza,

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -1813,10 +1813,10 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Key5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,ライセンスを確認,
 ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,ライセンス,
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,従来のライセンスキー,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,メジャーバージョン 2026 より前のインストール済みサービスでは、下の登録名とライセンスキーを使用してください。2026 以降のバージョンでは「ライセンスファイル」タブを使用してください。,
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,登録名とライセンスキーを使用する古いバージョンのインストール済みサービスでは、下に入力してください。バージョン 26 以降では「ライセンスファイル」タブを使用してください。,
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,従来のライセンス,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,ライセンス情報,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,メジャーバージョン 2026 以降のインストール済みサービスでは、ライセンスファイル (.alic) を使用します。既定の場所は %DEFAULTLICENSEV2PATH% です。それより古いサービスバージョンでは「従来のライセンス」タブを使用してください。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,バージョン 26 以降のインストール済みサービスでは、ライセンスファイル (.alic) を使用します。既定の場所は %DEFAULTLICENSEV2PATH% です。それより古いサービスバージョンでは「従来のライセンス」タブを使用してください。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,ライセンスファイル,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,既定のランタイムパス: %DEFAULTLICENSEV2PATH%。このフィールドを空にするとその場所を使用します。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,ライセンスファイル,

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -1807,10 +1807,10 @@ ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Chave5
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verifique a licença,
 ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licença,
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Chaves de licença legadas,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Para serviços instalados com versão principal anterior a 2026, use o nome de registro e as chaves de licença abaixo. Para a versão 2026 e posterior, use a guia Arquivo de licença.",
+ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Para serviços instalados mais antigos que usam nome de registro e chaves de licença, informe-os abaixo. Para a versão 26 e posterior, use a guia Arquivo de licença.",
 ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licença legada,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Informações sobre licença,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Para serviços instalados com versão principal 2026 ou posterior, use um arquivo de licença (.alic). O local padrão é %DEFAULTLICENSEV2PATH%. Para versões de serviço mais antigas, use a guia Licença legada.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Para serviços instalados com versão 26 ou posterior, use um arquivo de licença (.alic). O local padrão é %DEFAULTLICENSEV2PATH%. Para versões de serviço mais antigas, use a guia Licença legada.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Arquivo de licença,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Caminho padrão em runtime: %DEFAULTLICENSEV2PATH%. Deixe vazio para usar esse local.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Arquivo de licença,


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: f2bf2082638f44d2365251b7f83d5f9668a44f7d
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates client license messages in `clientcore` language CSVs to align with the new versioning (version 26+), and improves legacy license wording across eight locales. Keys and structure unchanged; placeholders like %DEFAULTLICENSEV2PATH% are preserved.

<sup>Written for commit 27418b1aef1a0bacea2eb7526e86cdea406fd421. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

