### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -151,7 +151,6 @@ ClientCore/frmConfig,Config Form,nTLSUseConfigurationCommands,Aktiviere OpenSSL 
 ClientCore/frmConfig,Config Form,nTimeOutLimit,Timeout Limit,
 ClientCore/frmConfig,Config Form,nUseDiscQueue,Nutze Diskqueue falls Verbindung zum Syslog Server fehlschlägt,
 ClientCore/frmConfig,Config Form,szActionCacheOptions,Action Queue bezogene Optionen,
-ClientCore/frmConfig,Config Form,szButtonCopyLicenseClipboard,Lizenzkey aus Zwischenablage kopieren,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusFailed,Ihre Lizenz scheint ungültig zu sein. Bitte überprüfen Sie die Schreibweise (Gross-/Kleinschreibung) und auf versehentliche Leerzeichen.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusSuccess,Ihre Lizenz scheint GÜLTIG zu sein.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusTitle,Lizenzprüfung,
@@ -919,11 +918,8 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Spracheinstellun
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Sie haben die Spracheinstellungen verändert.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,"Der Konfigurationsclient muss neu geladen werden, damit die Änderung durchgeführt werden kann.",
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Wollen Sie jetzt neuladen?,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"Der Lizenzschlüssel ist für dieses Produkt ungültig. Er kann falsch eingegeben sein, nicht zum Lizenznamen passen oder beschädigt sein. Prüfen Sie die Einstellungen unter Allgemein.",
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,"Dieser Lizenzschlüssel ist für diese Produktversion ungültig (falsche Release- bzw. Hauptversion). Sie benötigen einen Schlüssel, der zu diesem Build passt. Aktualisieren Sie die Lizenz unter Allgemein.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"Diese Lizenzdatei gilt für Hauptversion %LICENSEMAJORS%, der installierte Dienst meldet jedoch Hauptversion %SERVICEMAJOR%. Starten Sie den Dienst nach einem Update neu, damit die Lizenzierung übereinstimmt.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Es ist kein Lizenzschlüssel hinterlegt (Lizenzname oder Hauptschlüssel fehlt). Geben Sie Ihre Lizenz unter Allgemein ein oder aktualisieren Sie sie.,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,"Es ist keine gültige Lizenzdatei konfiguriert. Verwenden Sie die Registerkarte „Lizenzdatei“ unter Allgemein, um eine .alic-Lizenzdatei anzugeben oder bereitzustellen.",
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,"Es ist keine gültige Lizenzdatei konfiguriert. Verwenden Sie unter Allgemein die Lizenz, um eine .alic-Datei anzugeben oder bereitzustellen.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Keine gültige Lizenzdatei konfiguriert,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Lizenzdatei gültig,
@@ -1795,18 +1791,9 @@ ClientCore/xml.languagefiles/General.General,General General,sz_runhigh,Hoch,
 ClientCore/xml.languagefiles/General.General,General General,sz_runidle,Idle Priorität,
 ClientCore/xml.languagefiles/General.General,General General,sz_runlow,Niedrig,
 ClientCore/xml.languagefiles/General.General,General General,sz_runnormal,Normal,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey1,Key1,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey2,Key2,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Key3,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Key4,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Key5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Lizenz verifizieren,
-ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Lizenz,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Legacy-Lizenzschlüssel,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Für ältere installierte Dienste, die Registrierungsname und Lizenzschlüssel verwenden, tragen Sie diese unten ein. Für Version 26 und höher verwenden Sie die Registerkarte Lizenzdatei.",
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Legacy-Lizenz,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Lizenz Informationen,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,Für installierte Dienste mit Version 26 und höher verwenden Sie eine Lizenzdatei (.alic). Der Standardspeicherort ist %DEFAULTLICENSEV2PATH%. Für ältere Dienstversionen verwenden Sie die Registerkarte Legacy-Lizenz.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Legen Sie Ihre Lizenzdatei (.alic) unter %DEFAULTLICENSEV2PATH% ab, oder wählen Sie eine Datei aus bzw. ziehen Sie sie hierher. Lassen Sie das Feld leer, um den Standardpfad zu verwenden.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Lizenzdatei,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,"Standardpfad zur Laufzeit: %DEFAULTLICENSEV2PATH%. Feld leer lassen, um diesen Speicherort zu verwenden.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Lizenzdatei,
@@ -1836,11 +1823,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInva
 %1
 
 Diesen Pfad trotzdem speichern?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,Lizenzdatei,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Lizenzprüfung,
-ClientCore/xml.languagefiles/General.License,License General,szLicensee,Registrierungs-Name,
-ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Mehr Informationen unter auf unserer Homepage:,
-ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Lizenzschlüssel,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,nEnablePermittedSenders,Aktiviere erlaubte Senderliste.,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,permittedsenders,Empfange Nachrichten nur von folgenden IP-Adressen,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,szEditionInformation,"Bitte beachten Sie, dass wenn die Senderliste aktiviert wird alle Netzwerk Dienste auf die konfigurierten Adressen beschränkt werden. 

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -151,7 +151,6 @@ ClientCore/frmConfig,Config Form,nTLSUseConfigurationCommands,Use OpenSSL config
 ClientCore/frmConfig,Config Form,nTimeOutLimit,Timeout Limit,
 ClientCore/frmConfig,Config Form,nUseDiscQueue,Use Diskqueue if connection to Syslog Server fails,
 ClientCore/frmConfig,Config Form,szActionCacheOptions,Action Queue Options,
-ClientCore/frmConfig,Config Form,szButtonCopyLicenseClipboard,Import from Clipboard,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusFailed,Your license appears to be INVALID. Please check the spelling (case sensitive) and for accidental whitespaces.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusSuccess,Your license appears to be VALID.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusTitle,License Check,
@@ -923,11 +922,8 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Language Setting
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,You have changed the language settings.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,A reload of the Client application is needed in order to complete the changes.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Do you want to reload now?,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"The license key is not valid for this product. It may be mistyped, not match the license name, or be corrupted. Check General settings.",
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,This license key is not valid for this version of the product (wrong release / major version). You need a key that matches this build. Update your license in General settings.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"This license file is for major version %LICENSEMAJORS%, but the installed service reports major version %SERVICEMAJOR%. Restart the service after an update so licensing matches.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,No license key is configured (license name or primary key is missing). Enter or update your license in General settings.,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,No valid license file is configured. Use the License File tab under General settings to specify or deploy a .alic license file.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,No valid license file is configured. Use License under General settings to specify or deploy a .alic license file.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,No valid license file configured,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,License file valid,
@@ -1800,18 +1796,9 @@ ClientCore/xml.languagefiles/General.General,General General,sz_runhigh,High,
 ClientCore/xml.languagefiles/General.General,General General,sz_runidle,Run with idle priority,
 ClientCore/xml.languagefiles/General.General,General General,sz_runlow,Low ,
 ClientCore/xml.languagefiles/General.General,General General,sz_runnormal,Normal,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey1,Key1,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey2,Key2,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Key3,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Key4,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Key5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verify License,
-ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,License,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Legacy license keys,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"For older installed services that use registration name and license keys, enter them below. For version 26 and later, use the License File tab.",
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Legacy License,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,License Information,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"For installed services with version 26 and later, use a license file (.alic). The default location is %DEFAULTLICENSEV2PATH%. For older service versions, use the Legacy License tab.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Place your license file (.alic) at %DEFAULTLICENSEV2PATH%, or browse/drop a file below. Leave the path empty to use the default location.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,License File,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Default runtime path: %DEFAULTLICENSEV2PATH%. Leave this field empty to use that location.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,License File,
@@ -1841,11 +1828,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInva
 %1
 
 Save this path anyway?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,License File,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,License verification,
-ClientCore/xml.languagefiles/General.License,License General,szLicensee,Registration Name,
-ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,More information can be found at our Homepage,
-ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Registration Number,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,nEnablePermittedSenders,Enabled Permitted Senders List. ,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,permittedsenders,Only receive syslog messages from the following IP Addresses. ,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,szEditionInformation,"Please note that if you activate the Permitted Senders List, all network related services will be limited to receive messages from the configured devices only. 

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -151,7 +151,6 @@ ClientCore/frmConfig,Config Form,nTLSUseConfigurationCommands,Usar comandos de c
 ClientCore/frmConfig,Config Form,nTimeOutLimit,Límite de tiempo de espera,
 ClientCore/frmConfig,Config Form,nUseDiscQueue,Usar cola en disco si falla la conexión al servidor Syslog,
 ClientCore/frmConfig,Config Form,szActionCacheOptions,Opciones de cola de acciones,
-ClientCore/frmConfig,Config Form,szButtonCopyLicenseClipboard,Importar desde Portapapeles,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusFailed,Su licencia parece ser INVÁLIDA. Compruebe la ortografía (sensible a mayúsculas) y posibles espacios en blanco.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusSuccess,Su licencia parece ser VÁLIDA.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusTitle,Comprobación de licencia,
@@ -923,11 +922,8 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Configuración d
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Ha cambiado la configuración de idioma.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Es necesario reiniciar la aplicación cliente para completar los cambios.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,¿Desea reiniciar ahora?,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La clave de licencia no es válida para este producto. Puede estar mal escrita, no coincidir con el nombre de licencia o estar corrupta. Revise la configuración general.",
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Esta clave de licencia no es válida para esta versión del producto (versión o release incorrecta). Necesita una clave que corresponda a esta compilación. Actualice la licencia en la configuración general.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"Este archivo de licencia es para la versión principal %LICENSEMAJORS%, pero el servicio instalado informa la versión principal %SERVICEMAJOR%. Reinicie el servicio después de una actualización para que la licencia coincida.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,No hay clave de licencia configurada (falta el nombre de licencia o la clave principal). Introduzca o actualice su licencia en la configuración general.,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,No hay ningún archivo de licencia válido configurado. Use la pestaña Archivo de licencia en Configuración general para especificar o implementar un archivo de licencia .alic.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,No hay un archivo de licencia válido configurado. Use Licencia en Configuración general para especificar o implementar un archivo .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,No hay un archivo de licencia válido configurado,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Archivo de licencia válido,
@@ -1794,18 +1790,9 @@ ClientCore/xml.languagefiles/General.General,General General,sz_runhigh,Alto,
 ClientCore/xml.languagefiles/General.General,General General,sz_runidle,Prioridad inactiva,
 ClientCore/xml.languagefiles/General.General,General General,sz_runlow,Bajo,
 ClientCore/xml.languagefiles/General.General,General General,sz_runnormal,Normal,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey1,Clave1,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey2,Clave2,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Clave3,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Clave4,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Clave5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verificar licencia,
-ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licencia,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Claves de licencia heredadas,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Para servicios instalados más antiguos que usan nombre de registro y claves de licencia, introdúzcalos a continuación. Para la versión 26 y posteriores, use la pestaña Archivo de licencia.",
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licencia heredada,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Información de licencia,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Para servicios instalados con versión 26 y posteriores, use un archivo de licencia (.alic). La ubicación predeterminada es %DEFAULTLICENSEV2PATH%. Para versiones de servicio anteriores, use la pestaña Licencia heredada.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Coloque su archivo de licencia (.alic) en %DEFAULTLICENSEV2PATH%, o selecciónelo o arrástrelo aquí. Deje la ruta vacía para usar la ubicación predeterminada.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Archivo de licencia,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Ruta predeterminada en tiempo de ejecución: %DEFAULTLICENSEV2PATH%. Deje este campo vacío para usar esa ubicación.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Archivo de licencia,
@@ -1835,11 +1822,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInva
 %1
 
 ¿Guardar esta ruta de todos modos?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,Archivo de licencia,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Verificación de licencia,
-ClientCore/xml.languagefiles/General.License,License General,szLicensee,Nombre de registro,
-ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Puede encontrar más información en nuestra página de inicio,
-ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Número de registro,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,nEnablePermittedSenders,Lista de remitentes permitidos habilitada. ,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,permittedsenders,Recibir mensajes syslog solo desde las siguientes direcciones IP. ,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,szEditionInformation,"Tenga en cuenta que si activa la lista de remitentes permitidos, todos los servicios de red solo recibirán mensajes de los dispositivos configurados. 

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -151,7 +151,6 @@ ClientCore/frmConfig,Config Form,nTLSUseConfigurationCommands,Kasutage OpenSSL-i
 ClientCore/frmConfig,Config Form,nTimeOutLimit,Timeout Limit,
 ClientCore/frmConfig,Config Form,nUseDiscQueue,"Kasutage Diskqueue, kui ühendus serveriga Syslog ebaõnnestub",
 ClientCore/frmConfig,Config Form,szActionCacheOptions,Toimingu järjekorra valikud,
-ClientCore/frmConfig,Config Form,szButtonCopyLicenseClipboard,Import lõikelaualt,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusFailed,Teie litsents näib olevat KEHTNE. Kontrollige õigekirja (tõstutundlik) ja juhuslike tühikute olemasolu.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusSuccess,Teie litsents näib olevat KEHTIV.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusTitle,Litsentsi kontroll,
@@ -923,11 +922,8 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Keeleseadeid muu
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Olete muutnud keeleseadeid.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Muudatuste lõpuleviimiseks on vaja kliendirakendus uuesti laadida.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Kas soovite nüüd uuesti laadida?,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"Litsentsivõti ei kehti selle toote jaoks. See võib olla vale, mitte sobida litsentsi nimega või olla vigane. Kontrollige üldseadeid.",
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,See litsentsivõti ei kehti selle tooteversiooni jaoks (vale väljalaskenumber / peaversioon). Vajate sellele kompileeringule vastavat võtit. Uuendage litsents üldseadetes.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"See litsentsifail on peaversioonile %LICENSEMAJORS%, kuid installitud teenus teatab peaversiooni %SERVICEMAJOR%. Taaskäivitage teenus pärast uuendust, et litsents vastaks.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Litsentsivõtit pole seadistatud (puudub litsentsi nimi või põhivõti). Sisestage või uuendage litsents üldseadetes.,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Kehtivat litsentsifaili pole seadistatud. Kasutage .alic litsentsifaili määramiseks või juurutamiseks vahekaarti Litsentsifail üldseadetes.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,"Kehtivat litsentsifaili pole seadistatud. Kasutage üldseadetes jaotist Litsents, et määrata või paigutada .alic-fail.",
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Väljaanne (Versioon ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Kehtivat litsentsifaili pole seadistatud,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Litsentsifail kehtib,
@@ -1800,18 +1796,9 @@ ClientCore/xml.languagefiles/General.General,General General,sz_runhigh,Kõrge,
 ClientCore/xml.languagefiles/General.General,General General,sz_runidle,Käivitage tühikäigu prioriteediga,
 ClientCore/xml.languagefiles/General.General,General General,sz_runlow,Madal,
 ClientCore/xml.languagefiles/General.General,General General,sz_runnormal,Tavaline,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey1,Võti1,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey2,Võti2,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Võti 3,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Võti 4,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Võti 5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Kinnitage litsents,
-ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Litsents,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Pärandlitsentsi võtmed,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Vanemate installitud teenuste puhul, mis kasutavad registreerimisnime ja litsentsivõtmeid, sisestage need allpool. Versiooni 26 ja uuemate puhul kasutage vahekaarti Litsentsifail.",
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Pärandlitsents,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Litsentsi teave,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,Installitud teenuste puhul versiooniga 26 või uuem kasutage litsentsifaili (.alic). Vaikimisi asukoht on %DEFAULTLICENSEV2PATH%. Vanemate teenuseversioonide puhul kasutage vahekaarti Pärandlitsents.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,Paigutage oma litsentsifail (.alic) asukohta %DEFAULTLICENSEV2PATH% või sirvige/pukseerige fail allpool. Jätke tee tühjaks vaikeasukoha kasutamiseks.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Litsentsifail,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,"Vaikimisi käivitusteekond: %DEFAULTLICENSEV2PATH%. Jätke väli tühjaks, et kasutada seda asukohta.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Litsentsifail,
@@ -1841,11 +1828,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInva
 %1
 
 Kas salvestada see tee ikkagi?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,Litsentsifail,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Litsentsi kontroll,
-ClientCore/xml.languagefiles/General.License,License General,szLicensee,Registreerimisnimi,
-ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Lisateavet leiate meie kodulehelt,
-ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Registreerimisnumber,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,nEnablePermittedSenders,Lubatud saatjate loend.,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,permittedsenders,Saate syslogi sõnumeid ainult järgmistelt IP-aadressidelt.,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,szEditionInformation,"Pange tähele, et kui aktiveerite lubatud saatjate loendi, on kõik võrguga seotud teenused piiratud sõnumite vastuvõtmisega ainult konfigureeritud seadmetelt. 

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -151,7 +151,6 @@ ClientCore/frmConfig,Config Form,nTLSUseConfigurationCommands,Utiliser les comma
 ClientCore/frmConfig,Config Form,nTimeOutLimit,Limite de délai d'attente,
 ClientCore/frmConfig,Config Form,nUseDiscQueue,Utilisez Diskqueue si la connexion au serveur Syslog échoue,
 ClientCore/frmConfig,Config Form,szActionCacheOptions,Options de la file d'attente d'actions,
-ClientCore/frmConfig,Config Form,szButtonCopyLicenseClipboard,Importer depuis le Presse-papiers,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusFailed,Votre licence semble INVALIDE. Veuillez vérifier l'orthographe (sensible à la casse) et les espaces accidentels.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusSuccess,Votre licence semble être VALIDE.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusTitle,Vérification de la licence,
@@ -923,11 +922,8 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Paramètres de l
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Vous avez modifié les paramètres de langue.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Un rechargement de l'application Client est nécessaire pour finaliser les modifications.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Voulez-vous recharger maintenant ?,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La clé de licence n'est pas valide pour ce produit. Elle peut être incorrecte, ne pas correspondre au nom de licence ou être corrompue. Vérifiez les paramètres généraux.",
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Cette clé de licence n'est pas valide pour cette version du produit (mauvaise version / release). Il faut une clé adaptée à cette build. Mettez à jour votre licence dans les paramètres généraux.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"Ce fichier de licence est pour la version majeure %LICENSEMAJORS%, mais le service installé signale la version majeure %SERVICEMAJOR%. Redémarrez le service après une mise à jour pour que la licence corresponde.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Aucune clé de licence n'est configurée (nom de licence ou clé principale manquant). Saisissez ou mettez à jour votre licence dans les paramètres généraux.,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Aucun fichier de licence valide n'est configuré. Utilisez l'onglet Fichier de licence dans Paramètres généraux pour spécifier ou déployer un fichier de licence .alic.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Aucun fichier de licence valide n'est configuré. Utilisez Licence dans les paramètres généraux pour spécifier ou déployer un fichier .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Aucun fichier de licence valide configuré,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Fichier de licence valide,
@@ -1800,18 +1796,9 @@ ClientCore/xml.languagefiles/General.General,General General,sz_runhigh,Haut,
 ClientCore/xml.languagefiles/General.General,General General,sz_runidle,Exécuter avec une priorité inactive,
 ClientCore/xml.languagefiles/General.General,General General,sz_runlow,Faible,
 ClientCore/xml.languagefiles/General.General,General General,sz_runnormal,Normale,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey1,Clé1,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey2,Clé2,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Clé3,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Clé4,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Clé5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Vérifier la licence,
-ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licence,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Clés de licence héritées,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Pour les services installés plus anciens qui utilisent un nom d'enregistrement et des clés de licence, saisissez-les ci-dessous. Pour la version 26 et ultérieure, utilisez l'onglet Fichier de licence.",
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licence héritée,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Informations sur la licence,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Pour les services installés en version 26 ou ultérieure, utilisez un fichier de licence (.alic). L'emplacement par défaut est %DEFAULTLICENSEV2PATH%. Pour les versions de service plus anciennes, utilisez l'onglet Licence héritée.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Placez votre fichier de licence (.alic) dans %DEFAULTLICENSEV2PATH%, ou parcourez/déposez un fichier ci-dessous. Laissez le chemin vide pour utiliser l'emplacement par défaut.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Fichier de licence,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Chemin d'exécution par défaut : %DEFAULTLICENSEV2PATH%. Laissez ce champ vide pour utiliser cet emplacement.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Fichier de licence,
@@ -1841,11 +1828,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInva
 %1
 
 Enregistrer ce chemin quand même ?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,Fichier de licence,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Vérification de licence,
-ClientCore/xml.languagefiles/General.License,License General,szLicensee,Nom d'enregistrement,
-ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Plus d'informations peuvent être trouvées sur notre page d'accueil,
-ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Numéro d'enregistrement,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,nEnablePermittedSenders,Activation de la liste des expéditeurs autorisés.,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,permittedsenders,Recevez uniquement les messages Syslog des adresses IP suivantes.,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,szEditionInformation,"Veuillez noter que si vous activez la liste des expéditeurs autorisés, tous les services liés au réseau seront limités à la réception de messages provenant uniquement des appareils configurés. 

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -151,7 +151,6 @@ ClientCore/frmConfig,Config Form,nTLSUseConfigurationCommands,Utilizza i comandi
 ClientCore/frmConfig,Config Form,nTimeOutLimit,Limite di timeout,
 ClientCore/frmConfig,Config Form,nUseDiscQueue,Utilizzare Diskqueue se la connessione al server Syslog non riesce,
 ClientCore/frmConfig,Config Form,szActionCacheOptions,Opzioni di coda dell'azione,
-ClientCore/frmConfig,Config Form,szButtonCopyLicenseClipboard,Importa dagli appunti,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusFailed,La tua licenza sembra essere NON VALIDA. Si prega di controllare l'ortografia (con distinzione tra maiuscole e minuscole) e la presenza di spazi bianchi accidentali.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusSuccess,La tua licenza sembra essere VALIDA.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusTitle,Controllo della licenza,
@@ -923,11 +922,8 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Le impostazioni 
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Hai cambiato le impostazioni della lingua.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,Per completare le modifiche è necessario ricaricare l'applicazione Client.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Vuoi ricaricare adesso?,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"La chiave di licenza non è valida per questo prodotto. Potrebbe essere errata, non corrispondere al nome licenza o essere corrotta. Controllare le impostazioni generali.",
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Questa chiave di licenza non è valida per questa versione del prodotto (versione/release errata). È necessaria una chiave adatta a questa build. Aggiornare la licenza nelle impostazioni generali.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"Questo file di licenza è per la versione principale %LICENSEMAJORS%, ma il servizio installato riporta la versione principale %SERVICEMAJOR%. Riavviare il servizio dopo un aggiornamento affinché la licenza corrisponda.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Nessuna chiave di licenza configurata (manca il nome licenza o la chiave principale). Immettere o aggiornare la licenza nelle impostazioni generali.,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Nessun file di licenza valido configurato. Utilizzare la scheda File di licenza in Impostazioni generali per specificare o distribuire un file di licenza .alic.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Nessun file di licenza valido configurato. Usare Licenza nelle impostazioni generali per specificare o distribuire un file .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Nessun file di licenza valido configurato,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,File di licenza valido,
@@ -1800,18 +1796,9 @@ ClientCore/xml.languagefiles/General.General,General General,sz_runhigh,Alto,
 ClientCore/xml.languagefiles/General.General,General General,sz_runidle,Esegui con priorità inattiva,
 ClientCore/xml.languagefiles/General.General,General General,sz_runlow,Basso,
 ClientCore/xml.languagefiles/General.General,General General,sz_runnormal,Normale,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey1,Chiave1,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey2,Chiave2,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Chiave3,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Chiave4,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Chiave5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verifica licenza,
-ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licenza,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Chiavi di licenza legacy,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Per i servizi installati più vecchi che usano nome di registrazione e chiavi di licenza, inserirli sotto. Per la versione 26 e successive, usare la scheda File di licenza.",
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licenza legacy,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Informazioni sulla licenza,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Per i servizi installati con versione 26 o successiva, usare un file di licenza (.alic). La posizione predefinita è %DEFAULTLICENSEV2PATH%. Per versioni di servizio precedenti, usare la scheda Licenza legacy.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,Posizionare il file di licenza (.alic) in %DEFAULTLICENSEV2PATH% oppure cercare/trascinare un file qui sotto. Lasciare il percorso vuoto per usare la posizione predefinita.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,File di licenza,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Percorso predefinito in runtime: %DEFAULTLICENSEV2PATH%. Lasciare vuoto per usare tale percorso.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,File di licenza,
@@ -1841,11 +1828,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInva
 %1
 
 Salvare comunque questo percorso?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,File di licenza,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Verifica licenza,
-ClientCore/xml.languagefiles/General.License,License General,szLicensee,Nome di registrazione,
-ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Maggiori informazioni possono essere trovate sulla nostra homepage,
-ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Numero di registrazione,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,nEnablePermittedSenders,Elenco mittenti consentiti abilitato.,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,permittedsenders,Ricevi solo messaggi syslog dai seguenti indirizzi IP.,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,szEditionInformation,"Tieni presente che se attivi l'Elenco mittenti consentiti, tutti i servizi relativi alla rete saranno limitati a ricevere messaggi solo dai dispositivi configurati. 

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -151,7 +151,6 @@ ClientCore/frmConfig,Config Form,nTLSUseConfigurationCommands,OpenSSL 設定コ�
 ClientCore/frmConfig,Config Form,nTimeOutLimit,タイムアウトの設定,
 ClientCore/frmConfig,Config Form,nUseDiscQueue,サーバーに接続できない時にディスクキューを使用する,
 ClientCore/frmConfig,Config Form,szActionCacheOptions,アクション キュー オプション,JTC:Action Queue Options
-ClientCore/frmConfig,Config Form,szButtonCopyLicenseClipboard,クリップボードから貼り付け,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusFailed,ライセンスが無効のようです。ユーザー登録名が正しく入力されているかどうかご確認ください。,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusSuccess,有効なライセンスです。,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusTitle,ライセンスの確認,
@@ -919,11 +918,8 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,言語が変更�
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,言語を変更しますか？,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,変更するにはクライアントをリロードする必要があります,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,リロードしますか？,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,ライセンスキーはこの製品では無効です。誤入力、ライセンス名との不一致、またはデータ破損の可能性があります。一般設定を確認してください。,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,このライセンスキーはこの製品バージョンでは無効です（リリース／メジャーバージョンが一致しません）。このビルドに対応したキーが必要です。一般設定でライセンスを更新してください。,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,このライセンスファイルはメジャーバージョン %LICENSEMAJORS% 用ですが、インストール済みサービスはメジャーバージョン %SERVICEMAJOR% を報告しています。更新後はサービスを再起動してライセンスを一致させてください。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,ライセンスキーが設定されていません（ライセンス名または主キーがありません）。一般設定でライセンスを入力または更新してください。,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,有効なライセンスファイルが設定されていません。一般設定の「ライセンスファイル」タブで .alic ライセンスファイルを指定または配置してください。,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,有効なライセンス ファイルが設定されていません。[全般] の [ライセンス] で .alic ライセンス ファイルを指定または配置してください。,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,有効なライセンスファイルが設定されていません,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,ライセンスファイルは有効,
@@ -1805,18 +1801,9 @@ ClientCore/xml.languagefiles/General.General,General General,sz_runhigh,高,
 ClientCore/xml.languagefiles/General.General,General General,sz_runidle,アイドルクラス,
 ClientCore/xml.languagefiles/General.General,General General,sz_runlow,低,
 ClientCore/xml.languagefiles/General.General,General General,sz_runnormal,通常,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey1,Key1,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey2,Key2,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Key3,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Key4,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Key5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,ライセンスを確認,
-ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,ライセンス,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,従来のライセンスキー,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,登録名とライセンスキーを使用する古いバージョンのインストール済みサービスでは、下に入力してください。バージョン 26 以降では「ライセンスファイル」タブを使用してください。,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,従来のライセンス,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,ライセンス情報,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,バージョン 26 以降のインストール済みサービスでは、ライセンスファイル (.alic) を使用します。既定の場所は %DEFAULTLICENSEV2PATH% です。それより古いサービスバージョンでは「従来のライセンス」タブを使用してください。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,ライセンス ファイル (.alic) を %DEFAULTLICENSEV2PATH% に配置するか、下で参照またはドロップしてください。パスを空のままにすると既定の場所が使われます。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,ライセンスファイル,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,既定のランタイムパス: %DEFAULTLICENSEV2PATH%。このフィールドを空にするとその場所を使用します。,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,ライセンスファイル,
@@ -1846,11 +1833,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInva
 %1
 
 このパスを保存しますか?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,ライセンスファイル,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,ライセンス検証,
-ClientCore/xml.languagefiles/General.License,License General,szLicensee,ユーザー登録名,
-ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,詳細情報は以下...,
-ClientCore/xml.languagefiles/General.License,License General,szRegNumber,ユーザー登録番号,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,nEnablePermittedSenders,送信許可リストを有効にする,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,permittedsenders,次のIPアドレスからのSyslogメッセージのみ受信,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,szEditionInformation,"注意：送信許可リストを有効にすると、サービスに関連するすべてのネットワーク上で、設定されたデバイスからのメッセージ受信のみ受け付けます。

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -151,7 +151,6 @@ ClientCore/frmConfig,Config Form,nTLSUseConfigurationCommands,Use comandos de co
 ClientCore/frmConfig,Config Form,nTimeOutLimit,Limite de tempo limite,
 ClientCore/frmConfig,Config Form,nUseDiscQueue,Usar fila em disco se a conexão com o servidor Syslog falhar,
 ClientCore/frmConfig,Config Form,szActionCacheOptions,Opções de fila da ação,
-ClientCore/frmConfig,Config Form,szButtonCopyLicenseClipboard,Importar da área de transferência,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusFailed,Sua licença parece ser INVÁLIDA. Verifique a ortografia (diferencia maiúsculas de minúsculas) e se há espaços em branco acidentais.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusSuccess,Sua licença parece ser VÁLIDA.,
 ClientCore/frmConfig,Config Form,szCheckRegisterStatusTitle,Verificação de licença,
@@ -922,11 +921,8 @@ ClientCore/frmMainTemplate,Main Template Form,szLanguageChanged,Configurações 
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull1,Você alterou as configurações de idioma.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull2,É necessário recarregar o aplicativo Cliente para concluir as alterações.,
 ClientCore/frmMainTemplate,Main Template Form,szLanguageChangedFull3,Quer recarregar agora?,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyInvalid,"A chave de licença não é válida para este produto. Ela pode estar incorreta, não corresponder ao nome da licença ou estar corrompida. Verifique as configurações gerais.",
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerKeyWrongVersion,Esta chave de licença não é válida para esta versão do produto (versão/release incorreta). É necessária uma chave compatível com esta compilação. Atualize a licença em Configurações gerais.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerLicenseV2MajorVersionMismatch,"Este arquivo de licença é para a versão principal %LICENSEMAJORS%, mas o serviço instalado informa a versão principal %SERVICEMAJOR%. Reinicie o serviço após uma atualização para que a licença corresponda.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseData,Nenhuma chave de licença configurada (falta o nome da licença ou a chave principal). Informe ou atualize a licença em Configurações gerais.,
-ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Nenhum arquivo de licença válido está configurado. Use a guia Arquivo de licença em Configurações gerais para especificar ou implantar um arquivo de licença .alic.,
+ClientCore/frmMainTemplate,Main Template Form,szLicenseBannerNoLicenseFile,Nenhum arquivo de licença válido está configurado. Use Licença em Configurações gerais para especificar ou implantar um arquivo .alic.,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseEditionVersionSuffix, Edition (Version ,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusMissing,Nenhum arquivo de licença válido configurado,
 ClientCore/frmMainTemplate,Main Template Form,szLicenseFileStatusValid,Arquivo de licença válido,
@@ -1799,18 +1795,9 @@ ClientCore/xml.languagefiles/General.General,General General,sz_runhigh,Alto,
 ClientCore/xml.languagefiles/General.General,General General,sz_runidle,Executar com prioridade inativa,
 ClientCore/xml.languagefiles/General.General,General General,sz_runlow,Baixo,
 ClientCore/xml.languagefiles/General.General,General General,sz_runnormal,Normal,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey1,Chave1,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey2,Chave2,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey3,Chave3,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey4,Chave4,
-ClientCore/xml.languagefiles/General.License,License General,nLicenseKey5,Chave5,
 ClientCore/xml.languagefiles/General.License,License General,szButtonVerifyLicense,Verifique a licença,
-ClientCore/xml.languagefiles/General.License,License General,szDetailProperties,Licença,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicense,Chaves de licença legadas,
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseIntro,"Para serviços instalados mais antigos que usam nome de registro e chaves de licença, informe-os abaixo. Para a versão 26 e posterior, use a guia Arquivo de licença.",
-ClientCore/xml.languagefiles/General.License,License General,szLegacyLicenseTab,Licença legada,
 ClientCore/xml.languagefiles/General.License,License General,szLicense,Informações sobre licença,
-ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,"Para serviços instalados com versão 26 ou posterior, use um arquivo de licença (.alic). O local padrão é %DEFAULTLICENSEV2PATH%. Para versões de serviço mais antigas, use a guia Licença legada.",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
+ClientCore/xml.languagefiles/General.License,License General,szLicenseFileIntro,Coloque seu arquivo de licença (.alic) em %DEFAULTLICENSEV2PATH% ou procure/arraste um arquivo abaixo. Deixe o caminho vazio para usar o local padrão.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2,Arquivo de licença,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DefaultPath,Caminho padrão em runtime: %DEFAULTLICENSEV2PATH%. Deixe vazio para usar esse local.,PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2DeployTitle,Arquivo de licença,
@@ -1840,11 +1827,7 @@ ClientCore/xml.languagefiles/General.License,License General,szLicenseV2SaveInva
 %1
 
 Salvar este caminho mesmo assim?",PLACEHOLDER_REQUIRED: preserve %1/%2/etc exactly
-ClientCore/xml.languagefiles/General.License,License General,szLicenseV2Tab,Arquivo de licença,
 ClientCore/xml.languagefiles/General.License,License General,szLicenseV2VerifyTitle,Verificação de licença,
-ClientCore/xml.languagefiles/General.License,License General,szLicensee,Nome de registro,
-ClientCore/xml.languagefiles/General.License,License General,szMoreInformation,Mais informações podem ser encontradas em nossa página inicial,
-ClientCore/xml.languagefiles/General.License,License General,szRegNumber,Número de registro,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,nEnablePermittedSenders,Lista de remetentes permitidos habilitada.,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,permittedsenders,Receba apenas mensagens syslog dos seguintes endereços IP.,
 ClientCore/xml.languagefiles/General.Permitted,Permitted General,szEditionInformation,"Observe que, se você ativar a Lista de Remetentes Permitidos, todos os serviços relacionados à rede ficarão limitados a receber mensagens apenas dos dispositivos configurados.


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: d1417d4e505e85a0c97a91ef1fc0475ddc34c930
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes Adiscon Client language files to match the new license-file workflow and remove obsolete legacy key texts. Improves clarity in license banners and instructions across all supported languages.

- **Refactors**
  - Removed legacy license key strings and tabs (e.g., Key1–Key5, legacy license labels, invalid/wrong-version key banners).
  - Updated the “No license file” banner to direct users to General > License.
  - Rewrote License File intro to explain default path %DEFAULTLICENSEV2PATH% and browse/drag‑drop; kept placeholders intact.
  - Dropped the “Import from Clipboard” label.

<sup>Written for commit 29c41d2429b2b74b92b48d7de29f6c8f3d636d8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

