### PR TITLE
Update Adiscon Client language files

### DIFF
--- a/language-files/clientcore/de-DE.csv
+++ b/language-files/clientcore/de-DE.csv
@@ -1061,6 +1061,14 @@ ClientCore/frmMibBrowser,Mib Browser Form,lblTitle.Text,MIB Browser (OID),
 ClientCore/frmMibBrowser,Mib Browser Form,lblvarType.Text,Variablentyp:,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentError,Fehler beim Laden einer Komponente,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentErrorReloadMibs,Eine Komponente zum Laden der SNMP Mibs konnte nicht initialisiert werden. Der Konfigurations Client hat versucht das Problem zu beheben. Ein Neustart des Clients wird benötigt. Bitte starten Sie den Client neu und versuchen Sie es erneut.,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,$this.Text,Nicht unterstützte allgemeine Einstellungen,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnCancel.Text,Abbrechen,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnConvertScalars.Text,Skalare Einstellungen konvertieren,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnExportWithout.Text,Ohne Einstellungen exportieren,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,lblDescription.Text,"Die folgenden allgemeinen Einstellungen können beim Speichern nach {0} nicht beibehalten werden:
+{1}
+
+Abbrechen lässt die Konfiguration unverändert. Die Konvertierung skalarer Einstellungen ist nur möglich, wenn das Ziel jede beibehaltene Einstellung darstellen kann.",
 ClientCore/frmToolsConnect,Tools Connect Form,$this.Text,Connect,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdBrowse.Text,Browse,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdCancel.Text,Cancel,

--- a/language-files/clientcore/en-US.csv
+++ b/language-files/clientcore/en-US.csv
@@ -1065,6 +1065,14 @@ ClientCore/frmMibBrowser,Mib Browser Form,lblTitle.Text,MIB Browser (OID),
 ClientCore/frmMibBrowser,Mib Browser Form,lblvarType.Text,Variable Type:,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentError,Error loading component,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentErrorReloadMibs,"A component error occurred while loading SNMP Mibs. The configuration client tried to fix the problem, but a configuration client restart is needed. Please restart the Client and try again. ",
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,$this.Text,Unsupported General settings,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnCancel.Text,Cancel,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnConvertScalars.Text,Convert scalar settings,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnExportWithout.Text,Export without settings,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,lblDescription.Text,"The following General settings cannot be preserved when saving to {0}:
+{1}
+
+Cancel keeps the configuration unchanged. Scalar conversion is available only when the destination can represent every retained setting.",
 ClientCore/frmToolsConnect,Tools Connect Form,$this.Text,Connect,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdBrowse.Text,Browse,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdCancel.Text,Cancel,

--- a/language-files/clientcore/es-ES.csv
+++ b/language-files/clientcore/es-ES.csv
@@ -1065,6 +1065,14 @@ ClientCore/frmMibBrowser,Mib Browser Form,lblTitle.Text,Explorador MIB (OID),
 ClientCore/frmMibBrowser,Mib Browser Form,lblvarType.Text,Tipo de variable:,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentError,Error al cargar el componente,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentErrorReloadMibs,"Ocurrió un error de componente al cargar las MIBs SNMP. El cliente de configuración intentó corregir el problema, pero es necesario reiniciar el cliente de configuración. Reinicie el cliente e inténtelo de nuevo. ",
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,$this.Text,Configuración general no compatible,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnCancel.Text,Cancelar,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnConvertScalars.Text,Convertir valores escalares,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnExportWithout.Text,Exportar sin configuración,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,lblDescription.Text,"La siguiente configuración general no se puede conservar al guardar en {0}:
+{1}
+
+Cancelar mantiene la configuración sin cambios. La conversión de valores escalares solo está disponible si el destino puede representar todos los valores conservados.",
 ClientCore/frmToolsConnect,Tools Connect Form,$this.Text,Connect,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdBrowse.Text,Browse,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdCancel.Text,Cancel,

--- a/language-files/clientcore/et-EE.csv
+++ b/language-files/clientcore/et-EE.csv
@@ -1065,6 +1065,14 @@ ClientCore/frmMibBrowser,Mib Browser Form,lblTitle.Text,MIB-brauser (OID),
 ClientCore/frmMibBrowser,Mib Browser Form,lblvarType.Text,Muutuja tüüp:,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentError,Viga komponendi laadimisel,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentErrorReloadMibs,"SNMP Mibsi laadimisel ilmnes komponendi viga. Konfiguratsiooniklient üritas probleemi lahendada, kuid konfiguratsioonikliendi taaskäivitamine on vajalik. Taaskäivitage klient ja proovige uuesti.",
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,$this.Text,Toetamata üldsätted,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnCancel.Text,Loobu,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnConvertScalars.Text,Teisenda skalaarseid sätteid,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnExportWithout.Text,Ekspordi säteteta,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,lblDescription.Text,"Järgmisi üldsätteid ei saa vormingusse {0} salvestamisel säilitada:
+{1}
+
+Loobu jätab konfiguratsiooni muutmata. Skalaarsete sätete teisendamine on võimalik ainult siis, kui sihtkoht saab esitada kõik säilitatavad sätted.",
 ClientCore/frmToolsConnect,Tools Connect Form,$this.Text,Connect,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdBrowse.Text,Browse,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdCancel.Text,Cancel,

--- a/language-files/clientcore/fr-FR.csv
+++ b/language-files/clientcore/fr-FR.csv
@@ -1065,6 +1065,14 @@ ClientCore/frmMibBrowser,Mib Browser Form,lblTitle.Text,Navigateur MIB (OID),
 ClientCore/frmMibBrowser,Mib Browser Form,lblvarType.Text,Type de variable :,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentError,Erreur de chargement du composant,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentErrorReloadMibs,"Une erreur de composant s'est produite lors du chargement des Mibs SNMP. Le client de configuration a tenté de résoudre le problème, mais un redémarrage du client de configuration est nécessaire. Veuillez redémarrer le client et réessayer.",
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,$this.Text,Paramètres généraux non pris en charge,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnCancel.Text,Annuler,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnConvertScalars.Text,Convertir les paramètres scalaires,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnExportWithout.Text,Exporter sans paramètres,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,lblDescription.Text,"Les paramètres généraux suivants ne peuvent pas être conservés lors de l'enregistrement au format {0}:
+{1}
+
+Annuler laisse la configuration inchangée. La conversion des paramètres scalaires n'est disponible que si la destination peut représenter tous les paramètres conservés.",
 ClientCore/frmToolsConnect,Tools Connect Form,$this.Text,Connect,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdBrowse.Text,Browse,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdCancel.Text,Cancel,

--- a/language-files/clientcore/it-IT.csv
+++ b/language-files/clientcore/it-IT.csv
@@ -1065,6 +1065,14 @@ ClientCore/frmMibBrowser,Mib Browser Form,lblTitle.Text,Browser MIB (OID),
 ClientCore/frmMibBrowser,Mib Browser Form,lblvarType.Text,Tipo di variabile:,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentError,Errore durante il caricamento del componente,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentErrorReloadMibs,"Si è verificato un errore del componente durante il caricamento delle SNMP MIB. Il client di configurazione ha tentato di risolvere il problema, ma è necessario riavviare il client di configurazione. Riavvia il client e riprova.",
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,$this.Text,Impostazioni generali non supportate,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnCancel.Text,Annulla,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnConvertScalars.Text,Converti impostazioni scalari,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnExportWithout.Text,Esporta senza impostazioni,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,lblDescription.Text,"Le seguenti impostazioni generali non possono essere mantenute durante il salvataggio in {0}:
+{1}
+
+Annulla mantiene invariata la configurazione. La conversione delle impostazioni scalari è disponibile solo se la destinazione può rappresentare tutte le impostazioni mantenute.",
 ClientCore/frmToolsConnect,Tools Connect Form,$this.Text,Connect,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdBrowse.Text,Browse,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdCancel.Text,Cancel,

--- a/language-files/clientcore/ja-JP.csv
+++ b/language-files/clientcore/ja-JP.csv
@@ -1061,6 +1061,14 @@ ClientCore/frmMibBrowser,Mib Browser Form,lblTitle.Text,MIB ブラウザ (OID),
 ClientCore/frmMibBrowser,Mib Browser Form,lblvarType.Text,可変タイプ:,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentError,コンポーネント読み込みのエラー,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentErrorReloadMibs,SNMP MIB の読み込み中にコンポーネントエラーが発生しました。問題修復のために一旦設定クライアントを閉じ、再び起動させてください。 ,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,$this.Text,サポートされていない全般設定,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnCancel.Text,キャンセル,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnConvertScalars.Text,スカラー設定を変換,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnExportWithout.Text,設定を除外してエクスポート,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,lblDescription.Text,"次の全般設定は {0} に保存すると保持できません:
+{1}
+
+キャンセルすると構成は変更されません。スカラー設定の変換は、保存先ですべての保持対象設定を表現できる場合にのみ使用できます。",
 ClientCore/frmToolsConnect,Tools Connect Form,$this.Text,Connect,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdBrowse.Text,Browse,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdCancel.Text,Cancel,

--- a/language-files/clientcore/pt-BR.csv
+++ b/language-files/clientcore/pt-BR.csv
@@ -1064,6 +1064,14 @@ ClientCore/frmMibBrowser,Mib Browser Form,lblTitle.Text,Navegador MIB (OID),
 ClientCore/frmMibBrowser,Mib Browser Form,lblvarType.Text,Tipo de variável:,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentError,Erro ao carregar componente,
 ClientCore/frmMibBrowser,Mib Browser Form,szComponentErrorReloadMibs,"Ocorreu um erro de componente ao carregar Mibs SNMP. O cliente de configuração tentou corrigir o problema, mas é necessário reiniciar o cliente de configuração. Por favor reinicie o Cliente e tente novamente.",
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,$this.Text,Configurações gerais sem suporte,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnCancel.Text,Cancelar,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnConvertScalars.Text,Converter configurações escalares,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,btnExportWithout.Text,Exportar sem configurações,
+ClientCore/frmOpaqueGeneralExportOptions,Opaque General Export Options Form,lblDescription.Text,"As seguintes configurações gerais não podem ser preservadas ao salvar em {0}:
+{1}
+
+Cancelar mantém a configuração inalterada. A conversão de configurações escalares só está disponível quando o destino pode representar todas as configurações preservadas.",
 ClientCore/frmToolsConnect,Tools Connect Form,$this.Text,Connect,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdBrowse.Text,Navegar,
 ClientCore/frmToolsConnect,Tools Connect Form,cmdCancel.Text,Cancel,


### PR DESCRIPTION
Updates the exported Adiscon Client language CSV files.

AI review guidance:
- Review translated text values only; keep CSV keys and structure unchanged.
- Do not request translation of protected product names such as EventReporter, MonitorWare Agent, RSyslog Windows Agent, or WinSyslog.
- Title wording such as Configuration Client may be translated when the product name itself remains unchanged.
- Use the CSV Comment column as policy. PROTECTED_TERM means the product name inside the text must preserve its spelling and capitalization. PLACEHOLDER_REQUIRED means placeholders such as %1, %2, or %msg% must remain exact.

Source repository: Adiscon/adiscon-client
Source ref: c3e55984bc2c6a3c969e951d999d70a955146730
Trigger: push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds translations for the new Opaque General Export Options form (title, buttons, description) in the client core. Updates en-US, de-DE, es-ES, et-EE, fr-FR, it-IT, ja-JP, and pt-BR; CSV keys/structure unchanged and placeholders {0} and {1} preserved.

<sup>Written for commit ca0a85c3758617157824a67abe3865ad2591dc1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-community/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

